### PR TITLE
Factor out the groupby/partitioning stuff to be less obtrusive

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -17,7 +17,7 @@ def test_statistics(tempdir):
                        'z': ['a', 'b', 'c']})
 
     fn = os.path.join(tempdir, 'foo.parquet')
-    write(fn, df, partitions=[0, 2])
+    write(fn, df, row_group_offsets=[0, 2])
 
     p = ParquetFile(fn)
 
@@ -36,7 +36,7 @@ def test_logical_types(tempdir):
     df = pd.util.testing.makeMixedDataFrame()
 
     fn = os.path.join(tempdir, 'foo.parquet')
-    write(fn, df, partitions=[0, 2])
+    write(fn, df, row_group_offsets=[0, 2])
 
     p = ParquetFile(fn)
 
@@ -67,13 +67,13 @@ def test_empty_statistics(tempdir):
                                  'n_regionkey': [None]}}
 
 
-def test_sorted_partitioned_columns(tempdir):
+def test_sorted_row_group_columns(tempdir):
     df = pd.DataFrame({'x': [1, 2, 3, 4],
                        'y': [1.0, 2.0, 1.0, 2.0],
                        'z': ['a', 'b', 'c', 'd']})
 
     fn = os.path.join(tempdir, 'foo.parquet')
-    write(fn, df, partitions=[0, 2])
+    write(fn, df, row_group_offsets=[0, 2])
 
     pf = ParquetFile(fn)
 

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -81,9 +81,9 @@ def test_rle_bp():
 
 
 @pytest.mark.parametrize('scheme', ['simple', 'hive'])
-@pytest.mark.parametrize('partitions', [[0], [0, 500]])
+@pytest.mark.parametrize('row_groups', [[0], [0, 500]])
 @pytest.mark.parametrize('comp', [None] + list(compressions))
-def test_pyspark_roundtrip(tempdir, scheme, partitions, comp, sql):
+def test_pyspark_roundtrip(tempdir, scheme, row_groups, comp, sql):
     if comp == 'BROTLI':
         pytest.xfail("spark doesn't support BROTLI compression")
     data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
@@ -98,7 +98,7 @@ def test_pyspark_roundtrip(tempdir, scheme, partitions, comp, sql):
     data['cat'] = data.hello.astype('category')
 
     fname = os.path.join(tempdir, 'test.parquet')
-    write(fname, data, file_scheme=scheme, partitions=partitions,
+    write(fname, data, file_scheme=scheme, row_group_offsets=row_groups,
           compression=comp)
 
     df = sql.read.parquet(fname)
@@ -119,8 +119,8 @@ def test_roundtrip_s3(s3):
     data['cat'] = data.hello.astype('category')
     noop = lambda x: True
     myopen = lambda f: s3.open(f, 'wb')
-    write(TEST_DATA+'/temp_parq', data, file_scheme='hive', partitions=[0, 500],
-          open_with=myopen, mkdirs=noop)
+    write(TEST_DATA+'/temp_parq', data, file_scheme='hive',
+          row_group_offsets=[0, 500], open_with=myopen, mkdirs=noop)
     myopen = s3.open
     pf = ParquetFile(TEST_DATA+'/temp_parq', open_with=myopen)
     df = pf.to_pandas(categories=['cat', 'bcat'])
@@ -129,9 +129,9 @@ def test_roundtrip_s3(s3):
 
 
 @pytest.mark.parametrize('scheme', ['simple', 'hive'])
-@pytest.mark.parametrize('partitions', [[0], [0, 500]])
+@pytest.mark.parametrize('row_groups', [[0], [0, 500]])
 @pytest.mark.parametrize('comp', [None, 'GZIP', 'SNAPPY'])
-def test_roundtrip(tempdir, scheme, partitions, comp):
+def test_roundtrip(tempdir, scheme, row_groups, comp):
     data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
                          'i64': np.arange(1000, dtype=np.int64),
                          'f': np.arange(1000, dtype=np.float64),
@@ -143,7 +143,7 @@ def test_roundtrip(tempdir, scheme, partitions, comp):
     data['bcat'] = data.bhello.astype('category')
     data['cat'] = data.hello.astype('category')
     fname = os.path.join(tempdir, 'test.parquet')
-    write(fname, data, file_scheme=scheme, partitions=partitions,
+    write(fname, data, file_scheme=scheme, row_group_offsets=row_groups,
           compression=comp)
 
     r = ParquetFile(fname)
@@ -239,7 +239,7 @@ def test_empty_row_group(tempdir):
     fname = os.path.join(tempdir, 'temp.parq')
     data = pd.DataFrame({'o': np.random.choice(['hello', 'world'],
                                                size=1000)})
-    writer.write(fname, data, partitions=[0, 900, 1800])
+    writer.write(fname, data, row_group_offsets=[0, 900, 1800])
     pf = ParquetFile(fname)
     assert len(pf.row_groups) == 2
 
@@ -271,7 +271,7 @@ def test_groups_roundtrip(tempdir):
     for i, row in out.iterrows():
         assert row.b in list(df[(df.a==row.a)&(df.c==row.c)].b)
 
-    writer.write(tempdir, df, partitions=[0, 50], partition_on=['a', 'c'],
+    writer.write(tempdir, df, row_group_offsets=[0, 50], partition_on=['a', 'c'],
                  file_scheme='hive')
 
     r = ParquetFile(tempdir)
@@ -289,7 +289,7 @@ def test_empty_groupby(tempdir):
                        'c': np.random.choice([True, False], size=1000)})
     df.loc[499:, 'c'] = True  # no False in second half
     writer.write(tempdir, df, partition_on=['a', 'c'], file_scheme='hive',
-                 partitions=[0, 500])
+                 row_group_offsets=[0, 500])
     r = ParquetFile(tempdir)
     assert r.count == sum(~df.a.isnull())
     assert len(r.row_groups) == 6


### PR DESCRIPTION
The functionality still works, but now lives below the row-grouping,
which is the way it will be used with dask too.

Now the writer function is much cleaner.
