### PR TITLE
Read row group

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -112,8 +112,8 @@ class ParquetFile(object):
     def read_row_group_file(self, rg, columns, categories):
         """ Open file for reading, and process it as a row-group """
         fn = self.row_group_filename(rg)
-        return core.read_row_group_file(fn, self.open, rg, columns, categories,
-                self.helper, self.cats)
+        return core.read_row_group_file(fn, rg, columns, categories,
+                self.helper, self.cats, open=self.open)
 
     def read_row_group(self, rg, columns, categories, infile=None):
         """

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -1,15 +1,18 @@
 import io
-import numpy as np
 import os
-import pandas as pd
+import re
 import struct
+
+import numpy as np
+import pandas as pd
 from thriftpy.protocol.compact import TCompactProtocolFactory
 
 from . import encoding
+from .compression import decompress_data
 from .converted_types import convert
 from .thrift_filetransport import TFileTransport
 from .thrift_structures import parquet_thrift
-from .compression import decompress_data
+from .util import val_to_num
 
 
 def read_thrift(file_obj, ttype):
@@ -245,4 +248,34 @@ def read_col(column, schema_helper, infile, use_cat=False,
         out = pd.Series(final)
         if se.converted_type is not None:
             out = convert(out, se)
+    return out
+
+
+def read_row_group(rg, columns, categories, schema_helper, cats, infile=None):
+    """
+    Access row-group in a file and read some columns into a data-frame.
+    """
+    out = {}
+
+    for column in rg.columns:
+        name = ".".join(column.meta_data.path_in_schema)
+        if name not in columns:
+            continue
+
+        use = name in categories if categories is not None else False
+        s = read_col(column, schema_helper, infile, use_cat=use)
+        out[name] = s
+    out = pd.DataFrame(out, columns=columns)
+
+    # apply categories
+    for cat in cats:
+        # *Hard assumption*: all chunks in a row group have the
+        # same partition (correct for spark/hive)
+        partitions = re.findall("([a-zA-Z_]+)=([^/]+)/",
+                                rg.columns[0].file_path)
+        val = [p[1] for p in partitions if p[0] == cat][0]
+        codes = np.empty(rg.num_rows, dtype=np.int16)
+        codes[:] = cats[cat].index(val)
+        out[cat] = pd.Categorical.from_codes(
+                codes, [val_to_num(c) for c in cats[cat]])
     return out

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -251,7 +251,12 @@ def read_col(column, schema_helper, infile, use_cat=False,
     return out
 
 
-def read_row_group(rg, columns, categories, schema_helper, cats, infile=None):
+def read_row_group_file(fn, open, *args, **kwargs):
+    with open(fn, mode='rb') as f:
+        return read_row_group(f, *args, **kwargs)
+
+
+def read_row_group(file, rg, columns, categories, schema_helper, cats):
     """
     Access row-group in a file and read some columns into a data-frame.
     """
@@ -263,7 +268,7 @@ def read_row_group(rg, columns, categories, schema_helper, cats, infile=None):
             continue
 
         use = name in categories if categories is not None else False
-        s = read_col(column, schema_helper, infile, use_cat=use)
+        s = read_col(column, schema_helper, file, use_cat=use)
         out[name] = s
     out = pd.DataFrame(out, columns=columns)
 

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -251,9 +251,9 @@ def read_col(column, schema_helper, infile, use_cat=False,
     return out
 
 
-def read_row_group_file(fn, open, *args, **kwargs):
+def read_row_group_file(fn, columns, *args, open=open):
     with open(fn, mode='rb') as f:
-        return read_row_group(f, *args, **kwargs)
+        return read_row_group(f, columns, *args)
 
 
 def read_row_group(file, rg, columns, categories, schema_helper, cats):


### PR DESCRIPTION
This creates standalone functions to read row groups.  By removing the dependence on the ParquetFile we make it easier for remote workers to pull a small amount of data without understanding the full metadata of the entire ParquetFile.