### PR TITLE
Optimizations: column encodings

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -251,7 +251,7 @@ class ParquetFile(object):
         # pandas.types.concat.union_categoricals
         try:
             if num_row_groups > 1:
-                return pd.concat(tot, ignore_index=index is None)
+                return pd.concat(tot, ignore_index=index is None, copy=False)
             else:
                 return next(iter(tot))
         except (ValueError, StopIteration):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -254,7 +254,7 @@ class ParquetFile(object):
                 return pd.concat(tot, ignore_index=index is None)
             else:
                 return next(iter(tot))
-        except ValueError:
+        except (ValueError, StopIteration):
             return pd.DataFrame(columns=columns + list(self.cats))
 
     @property

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -244,12 +244,16 @@ class ParquetFile(object):
         Pandas data-frame
         """
         tot = self.iter_row_groups(columns, categories, filters, index)
+        num_row_groups = len(self.filter_row_groups(filters))
         columns = columns or self.columns
 
         # TODO: if categories vary from one rg to next, need
         # pandas.types.concat.union_categoricals
         try:
-            return pd.concat(tot, ignore_index=index is None)
+            if num_row_groups > 1:
+                return pd.concat(tot, ignore_index=index is None)
+            else:
+                return next(iter(tot))
         except ValueError:
             return pd.DataFrame(columns=columns + list(self.cats))
 

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -25,7 +25,7 @@ def time_column():
         d = pd.DataFrame({'w': pd.Categorical(np.random.choice(
                 ['hi', 'you', 'people'], size=n)),
                           'x': r.view('timedelta64[ns]'),
-                          'y': r.view('float64'),
+                          'y': r / np.random.randint(1, 1000, size=n),
                           'z': np.random.randint(0, 127, size=n,
                                                  dtype=np.uint8)})
 

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -121,9 +121,9 @@ def read_data_page(f, helper, header, metadata, skip_nulls=False,
                     metadata.path_in_schema[-1]).type_length
         else:
             bit_width = io_obj.read_byte()
-        if bit_width in [8, 16] and selfmade:
+        if bit_width in [8, 16, 32] and selfmade:
             num = (encoding.read_unsigned_var_int(io_obj) >> 1) * 8
-            values = io_obj.read(num).view('int8')
+            values = io_obj.read(num * bit_width // 8).view('int%i' % bit_width)
         elif bit_width:
             values = encoding.Numpy32(np.zeros(daph.num_values,
                                                dtype=np.int32))

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -268,7 +268,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
                 final[start:start+len(val)] = cval
                 start += len(val)
     if all_dict:
-        final = pd.Categorical.from_codes(final, categories=dic)
+        final = pd.Categorical(final, categories=dic, fastpath=True)
     return final
 
 

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -316,8 +316,9 @@ def read_row_group(file, rg, columns, categories, schema_helper, cats,
         c = list(out)[0]
         out = pd.DataFrame(out[c].reshape(-1, 1), columns=[c], index=i)
     elif len(dtypes) == 1 and dtypes != {'category'}:
-        out = pd.DataFrame(np.hstack([d.reshape(-1, 1) for d in out.values()]),
-                           columns=list(out))
+        columns = list(sorted(out))
+        out = pd.DataFrame(np.hstack([out[k].reshape(-1, 1) for k in columns]),
+                           columns=columns)
     else:
         out = pd.DataFrame(out, index=i)
     if i is not None:

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -342,7 +342,11 @@ def test_empty_groupby(tempdir):
         assert row.b in list(df[(df.a==row.a)&(df.c==row.c)].b)
 
 
-
+@pytest.mark.parametrize('compression', ['GZIP',
+                                         'gzip',
+                                         None,
+                                         {'x': 'GZIP'},
+                                         {'y': 'gzip', 'x': None}])
 def test_write_compression_dict(tempdir, compression):
     df = pd.DataFrame({'x': [1, 2, 3],
                        'y': [1., 2., 3.]})

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -161,6 +161,7 @@ def test_roundtrip_complex(tempdir, scheme,):
     import datetime
     data = pd.DataFrame({'ui32': np.arange(1000, dtype=np.uint32),
                          'i16': np.arange(1000, dtype=np.int16),
+                         'ui8': np.array([1, 2, 3, 4]*250, dtype=np.uint8),
                          'f16': np.arange(1000, dtype=np.float16),
                          'dicts': [{'oi': 'you'}] * 1000,
                          't': [datetime.datetime.now()] * 1000,

--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -461,6 +461,7 @@ def test_auto_null(tempdir):
                        'b': [1., 2., 3., np.nan],
                        'c': pd.to_timedelta([1, 2, 3, np.nan], unit='ms'),
                        'd': ['a', 'b', 'c', None]})
+    df['e'] = df['d'].astype('category')
     fn = os.path.join(tmp, "test.parq")
 
     with pytest.raises(TypeError):
@@ -472,7 +473,7 @@ def test_auto_null(tempdir):
     for col in pf.schema[2:]:
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     assert pf.schema[1].repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
-    df2 = pf.to_pandas()
+    df2 = pf.to_pandas(categories=['e'])
     tm.assert_frame_equal(df, df2)
 
     write(fn, df, has_nulls=None)
@@ -480,6 +481,6 @@ def test_auto_null(tempdir):
     for col in pf.schema[1:3]:
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
     assert pf.schema[4].repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
-    df2= pf.to_pandas()
+    df2= pf.to_pandas(categories=['e'])
     tm.assert_frame_equal(df, df2)
 

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -386,7 +386,10 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
     tot_rows = len(data)
 
     if has_nulls:
-        num_nulls = len(data) - data.count()
+        if str(data.dtype) == 'category':
+            num_nulls = (data.cat.codes == -1).sum()
+        else:
+            num_nulls = len(data) - data.count()
         definition_data, data = make_definitions(data, num_nulls == 0)
     else:
         definition_data = b""

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -155,7 +155,7 @@ def find_type(data, convert=False, fixed_text=None):
     return se, type, out
 
 
-@numba.njit()
+@numba.njit(nogil=True)
 def time_shift(indata, outdata, factor=1000):
     for i in range(len(indata)):
         if indata[i] == nat:
@@ -424,7 +424,7 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
         write_thrift(f, ph)
         f.write(bdata)
         try:
-            max, min = data.max(), data.min()
+            max, min = data.values.max(), data.values.min()
             max = encode['PLAIN'](pd.Series([max]), selement,
                                   fixed_text=fixed_text)
             min = encode['PLAIN'](pd.Series([min]), selement,
@@ -440,7 +440,7 @@ def write_column(f, data, selement, encoding='PLAIN', compression=None):
                                                                  fixed_text)
     try:
         if encoding != 'PLAIN_DICTIONARY':
-            max, min = data.max(), data.min()
+            max, min = data.values.max(), data.values.min()
             max = encode['PLAIN'](pd.Series([max], dtype=data.dtype), selement,
                                   fixed_text=fixed_text)
             min = encode['PLAIN'](pd.Series([min], dtype=data.dtype), selement,

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -320,7 +320,7 @@ def encode_rle_bp(data, width, o, withlength=False):
 def encode_dict(data, se, _):
     """ The data part of dictionary encoding is always int8, with RLE/bitpack
     """
-    width = 8
+    width = data.values.dtype.itemsize * 8
     o = encoding.Numpy8(np.empty(10, dtype=np.uint8))
     o.write_byte(width)
     bit_packed_count = (len(data) + 7) // 8


### PR DESCRIPTION
Times for 10M values:

On Master:
category: read, no nulls 310.246
category: read, no nulls, has_null=True 316.878
category: read, with null, has_null=False 306.243
category: read, with null, has_null=True 310.223
category: write, no nulls 141.021
category: write, no nulls, has_null=True 535.763
category: write, with null, has_null=False 122.86
category: write, with null, has_null=True 544.889

Latest in this branch:
category: read, no nulls 50.333
category: read, no nulls, has_null=True 48.35
category: read, with null, has_null=False 49.018
category: read, with null, has_null=True 50.351
category: write, no nulls 13.652
category: write, no nulls, has_null=True 113.637
category: write, with null, has_null=False 14.475
category: write, with null, has_null=True 105.193
