### PR TITLE
Reject column names which are not str/bytes

### DIFF
--- a/fastparquet/test/test_writer.py
+++ b/fastparquet/test/test_writer.py
@@ -156,6 +156,14 @@ def test_roundtrip(tempdir, scheme, row_groups, comp):
         assert (df[col] == data[col]).all()
 
 
+def test_bad_coltype(tempdir):
+    df = pd.DataFrame({'0': [1, 2], (0, 1): [3, 4]})
+    fn = os.path.join(tempdir, 'temp.parq')
+    with pytest.raises(ValueError) as e:
+        write(fn, df)
+        assert "tuple" in str(e)
+
+
 @pytest.mark.parametrize('scheme', ('simple', 'hive'))
 def test_roundtrip_complex(tempdir, scheme,):
     import datetime

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -509,6 +509,10 @@ def make_row_group(f, data, schema, file_path=None, compression=None,
     rows = len(data)
     if rows == 0:
         return
+    if any(not isinstance(c, (bytes, str)) for c in data):
+        raise ValueError('Column names must be str or bytes:',
+                         {c: type(c) for c in data.columns
+                          if not isinstance(c, (bytes, str))})
     rg = parquet_thrift.RowGroup(num_rows=rows, total_byte_size=0, columns=[])
 
     for column in schema:


### PR DESCRIPTION
We do not guess how to convert the column name, leave that to the user.
Instead we raise a helpful error message

Fixes #41 