### PR TITLE
Add conversion for decimals stored as bytestrings

### DIFF
--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -109,8 +109,8 @@ def convert(data, se):
             # NB: general but slow method
             # could optimize when data.dtype.itemsize <= 8
             # NB: `from_bytes` may be py>=3.4 only
-            return np.array([int.from_bytes(d, byteorder='big', signed=True)
-                             for d in data]) * scale_factor
+            return np.array([int.from_bytes(d, byteorder='big', signed=True) *
+                             scale_factor for d in data])
     elif ctype == parquet_thrift.ConvertedType.DATE:
         return (data * DAYS_TO_MILLIS).view('datetime64[ns]')
     elif ctype == parquet_thrift.ConvertedType.TIME_MILLIS:

--- a/fastparquet/test/test_converted_types.py
+++ b/fastparquet/test/test_converted_types.py
@@ -127,3 +127,22 @@ def test_uint64():
         converted_type=pt.ConvertedType.UINT_64
     )
     assert convert(pd.Series([-6884376]), schema)[0] == 18446744073702667240
+
+
+def test_big_decimal():
+    schema = pt.SchemaElement(
+        type=pt.Type.FIXED_LEN_BYTE_ARRAY,
+        name="test",
+        converted_type=pt.ConvertedType.DECIMAL,
+        type_length=32,
+        scale=1,
+        precision=38
+    )
+    data = np.array([
+    b'', b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1e\\',
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1d\\',
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\r{',
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x19)'],
+            dtype='|S32')
+    assert np.isclose(convert(data, schema),
+                      np.array([0., 777.2, 751.6, 345.1, 644.1])).all()


### PR DESCRIPTION
Fixes #48 

Much more efficient numpy methods exist when the input int is small
enough to be an int64 - but assume this is rare and not required until
requested.