### PR TITLE
Cython speedups for utf8 and variable length byte arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.pyc
+*.so
+*.dll
+fastparquet/speedups.c
 .coverage
 cover
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - pip install bson
 
 script:
-  - pip install .
+  - pip install -e .
   - py.test -x -vv --pyargs fastparquet
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ install:
   # Install dependencies
   - conda create -n test python=$TRAVIS_PYTHON_VERSION pytest
   - source activate test
-  - conda install numpy pandas numba thriftpy python-snappy
+  - conda install numpy pandas numba thriftpy python-snappy cython
   - pip install bson
 
 script:
+  - pip install .
   - py.test -x -vv --pyargs fastparquet
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # Install dependencies
   - conda create -n test python=$TRAVIS_PYTHON_VERSION pytest
   - source activate test
-  - conda install numpy pandas numba thriftpy python-snappy cython
+  - conda install numpy pandas numba thriftpy python-snappy cython setuptools
   - pip install bson
 
 script:

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -110,8 +110,7 @@ def time_text():
 
 if __name__ == '__main__':
     result = {}
-    #for f in [time_column, time_text]:
-    for f in [time_text]:
+    for f in [time_column, time_text]:
         result.update(f())
     for k in sorted(result):
         print(k, result[k])

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -110,7 +110,8 @@ def time_text():
 
 if __name__ == '__main__':
     result = {}
-    for f in [time_column, time_text]:
+    #for f in [time_column, time_text]:
+    for f in [time_text]:
         result.update(f())
     for k in sorted(result):
         print(k, result[k])

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -99,16 +99,8 @@ def convert(data, se):
         return data
     if ctype == parquet_thrift.ConvertedType.UTF8:
         if isinstance(data, list) or data.dtype != "O":
-            out = np.array(data, dtype="O")
-        else:
-            out = data
-        out = array_decode_utf8(out)
-        #if isinstance(data, list) or data.dtype != "O":
-            #out = np.empty(len(data), dtype="O")
-        #else:
-            #out = data
-        #out[:] = [s.decode('utf8') for s in data]
-        return out
+            data = np.array(data, dtype="O")
+        return array_decode_utf8(data)
     if ctype == parquet_thrift.ConvertedType.DECIMAL:
         scale_factor = 10**-se.scale
         if data.dtype.kind in ['i', 'f']:

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -24,6 +24,9 @@ import sys
 from decimal import Decimal
 
 from .thrift_structures import parquet_thrift
+from .speedups import array_decode_utf8
+
+
 logger = logging.getLogger('parquet')  # pylint: disable=invalid-name
 
 try:
@@ -96,10 +99,15 @@ def convert(data, se):
         return data
     if ctype == parquet_thrift.ConvertedType.UTF8:
         if isinstance(data, list) or data.dtype != "O":
-            out = np.empty(len(data), dtype="O")
+            out = np.array(data, dtype="O")
         else:
             out = data
-        out[:] = [s.decode('utf8') for s in data]
+        out = array_decode_utf8(out)
+        #if isinstance(data, list) or data.dtype != "O":
+            #out = np.empty(len(data), dtype="O")
+        #else:
+            #out = data
+        #out[:] = [s.decode('utf8') for s in data]
         return out
     if ctype == parquet_thrift.ConvertedType.DECIMAL:
         scale_factor = 10**-se.scale

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -13,6 +13,7 @@ import os
 import struct
 import sys
 
+from .speedups import unpack_byte_array
 from .thrift_structures import parquet_thrift
 
 
@@ -42,9 +43,7 @@ def read_plain(raw_bytes, type_, count, width=0):
     if type_ == parquet_thrift.Type.BOOLEAN:
         return read_plain_boolean(raw_bytes, count)
     # variable byte arrays (rare)
-    file_obj = io.BytesIO(raw_bytes)
-    return np.array([file_obj.read(struct.unpack('<i', file_obj.read(4))[0])
-                     for _ in range(count)], dtype="O")
+    return np.array(unpack_byte_array(raw_bytes, count), dtype='O')
 
 
 @numba.jit(nogil=True)

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -1,0 +1,152 @@
+"""
+Native accelerators for Parquet encoding and decoding.
+"""
+
+cdef extern from "string.h":
+    void *memcpy(void *dest, const void *src, size_t n)
+
+from cpython cimport (PyUnicode_AsUTF8String, PyUnicode_DecodeUTF8,
+                      PyBytes_CheckExact, PyBytes_FromStringAndSize,
+                      PyBytes_GET_SIZE, PyBytes_AS_STRING)
+
+import numpy as np
+cimport numpy as np
+
+
+_obj_dtype = np.dtype('object')
+
+
+def _to_array(obj):
+    """
+    Convert *obj* (a ndarray-compatible object, e.g. pandas Series)
+    to a true ndarray.
+    """
+    if not isinstance(obj, np.ndarray):
+        try:
+            obj = obj.__array__()
+        except AttributeError:
+            raise TypeError("expected an ndarray-compatible object, got %r"
+                            % (type(obj,)))
+        assert isinstance(obj, np.ndarray)
+    return obj
+
+
+def _check_1d_object_array(np.ndarray arr):
+    if arr.ndim != 1:
+        raise TypeError("expected a 1d array")
+    if arr.dtype != _obj_dtype:
+        raise TypeError("expected an object array")
+
+
+def array_encode_utf8(inp):
+    """
+    utf-8 encode all elements of a 1d ndarray of "object" dtype.
+    A new ndarray is returned.
+    """
+    cdef:
+        Py_ssize_t i, n
+        np.ndarray[object] arr
+        np.ndarray[object] out
+
+    arr = _to_array(inp)
+    _check_1d_object_array(arr)
+
+    n = len(arr)
+    result = np.empty(n, dtype=object)
+    for i in range(n):
+        result[i] = PyUnicode_AsUTF8String(arr[i])
+
+    return result
+
+
+def array_decode_utf8(inp):
+    """
+    utf-8 decode all elements of a 1d ndarray of "object" dtype.
+    A new ndarray is returned.
+    """
+    cdef:
+        Py_ssize_t i, n
+        np.ndarray[object] arr
+        np.ndarray[object] out
+        object val
+
+    arr = _to_array(inp)
+    _check_1d_object_array(arr)
+
+    n = len(arr)
+    result = np.empty(n, dtype=object)
+    for i in range(n):
+        val = arr[i]
+        if not PyBytes_CheckExact(val):
+            raise TypeError("expected array of bytes")
+        result[i] = PyUnicode_DecodeUTF8(
+            PyBytes_AS_STRING(val),
+            PyBytes_GET_SIZE(val),
+            NULL,   # errors
+            )
+
+    return result
+
+
+def pack_byte_array(list items):
+    """
+    Pack a variable length byte array column.
+    A bytes object is returned.
+    """
+    cdef:
+        Py_ssize_t i, n, itemlen, total_size
+        unsigned char *start
+        unsigned char *data
+        object val, out
+
+    n = len(items)
+    total_size = 0
+    for i in range(n):
+        val = items[i]
+        if not PyBytes_CheckExact(val):
+            raise TypeError("expected list of bytes")
+        total_size += 4 + PyBytes_GET_SIZE(items[i])
+
+    out = PyBytes_FromStringAndSize(NULL, total_size)
+    start = data = <unsigned char *> PyBytes_AS_STRING(out)
+
+    for i in range(n):
+        val = items[i]
+        # `itemlen` should be >= 0, so no signed extension issues
+        itemlen = PyBytes_GET_SIZE(val)
+        data[0] = itemlen & 0xff
+        data[1] = (itemlen >> 8) & 0xff
+        data[2] = (itemlen >> 16) & 0xff
+        data[3] = (itemlen >> 24) & 0xff
+        data += 4
+        memcpy(data, PyBytes_AS_STRING(val), itemlen)
+        data += itemlen
+
+    assert (data - start) == total_size
+    return out
+
+
+def unpack_byte_array(bytes raw_bytes, Py_ssize_t n):
+    """
+    Unpack a variable length byte array column.
+    A list of bytes objects is returned.
+    """
+    cdef:
+        Py_ssize_t i, itemlen
+        unsigned char *start
+        unsigned char *data
+        list out
+
+    start = data = <unsigned char *> PyBytes_AS_STRING(raw_bytes)
+    out = [None] * n
+
+    for i in range(n):
+        itemlen = (data[0] + (data[1] << 8) +
+                   (data[2] << 16) + (data[3] << 24))
+        data += 4
+        out[i] = PyBytes_FromStringAndSize(<char *> data, itemlen)
+        data += itemlen
+
+    assert (data - start) <= len(raw_bytes)
+    return out
+

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -108,7 +108,7 @@ def pack_byte_array(list items):
         val = items[i]
         if not PyBytes_CheckExact(val):
             raise TypeError("expected list of bytes")
-        total_size += 4 + PyBytes_GET_SIZE(items[i])
+        total_size += 4 + PyBytes_GET_SIZE(val)
 
     out = PyBytes_FromStringAndSize(NULL, total_size)
     start = data = <unsigned char *> PyBytes_AS_STRING(out)

--- a/fastparquet/test/test_speedups.py
+++ b/fastparquet/test/test_speedups.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+import struct
+
+import pytest
+
+import numpy as np
+
+import pandas as pd
+import pandas.util.testing as tm
+
+from fastparquet.speedups import (
+    array_encode_utf8, array_decode_utf8,
+    pack_byte_array, unpack_byte_array
+    )
+
+
+strings = ["abc", "a\x00c", "héhé", "プログラミング"]
+
+
+def test_array_encode_utf8():
+    arr = np.array(strings, dtype='object')
+    expected = [s.encode('utf-8') for s in strings]
+    got = array_encode_utf8(arr)
+
+    assert got.dtype == np.dtype('object')
+    assert list(got) == expected
+
+    ser = pd.Series(arr)
+    got = array_encode_utf8(ser)
+
+    assert got.dtype == np.dtype('object')
+    assert list(got) == expected
+
+    # Non-encodable string (lone surrogate)
+    invalid_string = "\uDE80"
+    arr = np.array(strings + [invalid_string], dtype='object')
+    with pytest.raises(UnicodeEncodeError):
+        array_encode_utf8(arr)
+
+    # Wrong array type
+    arr = np.array(strings, dtype='U')
+    with pytest.raises((TypeError, ValueError)):
+        array_encode_utf8(arr)
+
+    # Wrong object type
+    arr = np.array([b"foo"], dtype='object')
+    with pytest.raises(TypeError):
+        array_encode_utf8(arr)
+
+
+def test_array_decode_utf8():
+    bytestrings = [s.encode('utf-8') for s in strings]
+
+    arr = np.array(bytestrings, dtype='object')
+    expected = list(strings)
+    got = array_decode_utf8(arr)
+
+    assert got.dtype == np.dtype('object')
+    assert list(got) == expected
+
+    # Non-decodable string
+    arr = np.array(bytestrings + [b"\x00\xff"], dtype='object')
+    with pytest.raises(UnicodeDecodeError):
+        array_decode_utf8(arr)
+
+    # Wrong array type
+    arr = np.array(bytestrings, dtype='S')
+    with pytest.raises((TypeError, ValueError)):
+        array_decode_utf8(arr)
+
+    # Wrong object type
+    arr = np.array(["foo"], dtype='object')
+    with pytest.raises(TypeError):
+        array_decode_utf8(arr)
+
+
+def test_pack_byte_array():
+    bytestrings = [b"foo", b"bar\x00" * 256 + b"z"]
+
+    expected = b''.join(struct.pack('<L', len(b)) + b
+                        for b in bytestrings)
+
+    b = pack_byte_array(bytestrings)
+    assert b == expected
+
+    b = pack_byte_array([])
+    assert b == b''
+
+    with pytest.raises(TypeError):
+        pack_byte_array(tuple(bytestrings))
+
+    with pytest.raises(TypeError):
+        pack_byte_array(bytestrings + ["foo"])
+
+    with pytest.raises(TypeError):
+        pack_byte_array(b"foo")
+
+
+def test_unpack_byte_array():
+    bytestrings = [b"foo", b"bar\x00" * 256 + b"z"]
+
+    packed = b''.join(struct.pack('<L', len(b)) + b
+                      for b in bytestrings)
+
+    seq = unpack_byte_array(packed, len(bytestrings))
+    assert seq == bytestrings
+
+    def check_invalid_length(b, n):
+        with pytest.raises(RuntimeError):
+            unpack_byte_array(b, n)
+
+    check_invalid_length(packed, len(bytestrings) - 1)
+    check_invalid_length(packed, len(bytestrings) + 1)
+    check_invalid_length(packed + b'\x00', len(bytestrings))
+    check_invalid_length(packed + b'\x01\x02\x03\x04', len(bytestrings))
+    check_invalid_length(packed[:-1], len(bytestrings))
+    check_invalid_length(packed[:-1], len(bytestrings))

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
 """setup.py - build script for parquet-python."""
 
 import os
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 
-from setuptools import setup, Extension
+import numpy as np
 
 from Cython.Build import cythonize
 
+
 cython_modules = [Extension('fastparquet.speedups',
-                            ['fastparquet/speedups.pyx'])]
+                            ['fastparquet/speedups.pyx'],
+                            include_dirs=[np.get_include()])]
 
 ext_modules = cythonize(cython_modules)
 

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 
 import os
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 from Cython.Build import cythonize
 

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,23 @@
 import os
 
 try:
-    from setuptools import setup
+    from setuptools import setup, Extension
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, Extension
+
+from Cython.Build import cythonize
+
+cython_modules = [Extension('fastparquet.speedups',
+                            ['fastparquet/speedups.pyx'])]
+
+ext_modules = cythonize(cython_modules)
+
 
 setup(
     name='fastparquet',
     version='0.0.3',
     description='Python support for Parquet file format',
+    ext_modules=ext_modules,
     author='Joe Crobak, Martin Durant',
     author_email='mdurant@continuum.io',
     url='https://github.com/martindurant/fastparquet/',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.0.4',
     description='Python support for Parquet file format',
     ext_modules=ext_modules,
-    author='Joe Crobak, Martin Durant',
+    author='Martin Durant',
     author_email='mdurant@continuum.io',
     url='https://github.com/martindurant/fastparquet/',
     license='Apache License 2.0',


### PR DESCRIPTION
Before:
```
bytes: read, fixed: 6 54.659
bytes: read, fixed: None 548.77
bytes: write, fixed: 6 130.661
bytes: write, fixed: None 507.314
utf8: read, fixed: 6 466.556
utf8: read, fixed: None 948.561
utf8: write, fixed: 6 464.908
utf8: write, fixed: None 777.69
```
After:
```
bytes: read, fixed: 6 55.002
bytes: read, fixed: None 79.554
bytes: write, fixed: 6 123.404
bytes: write, fixed: None 142.213
utf8: read, fixed: 6 162.496
utf8: read, fixed: None 175.973
utf8: write, fixed: 6 209.835
utf8: write, fixed: None 191.901
```