### PR TITLE
If definitions has extra unused bytes, seek to right location

### DIFF
--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -126,7 +126,7 @@ def read_data_page(f, helper, header, metadata, skip_nulls=False,
             num = (encoding.read_unsigned_var_int(io_obj) >> 1) * 8
             values = io_obj.read(num * bit_width // 8).view('int%i' % bit_width)
         elif bit_width:
-            values = encoding.Numpy32(np.zeros(daph.num_values,
+            values = encoding.Numpy32(np.empty(daph.num_values-num_nulls+7,
                                                dtype=np.int32))
             # length is simply "all data left in this page"
             encoding.read_rle_bit_packed_hybrid(

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -145,6 +145,7 @@ def read_rle_bit_packed_hybrid(io_obj, width, length=None, o=None):  # pragma: n
             read_rle(io_obj, header, width, o)
         else:
             read_bitpacked(io_obj, header, width, o)
+    io_obj.loc = start + length
     return o.so_far()
 
 

--- a/fastparquet/test/test_with_n.py
+++ b/fastparquet/test/test_with_n.py
@@ -57,6 +57,25 @@ def test_hybrid():
             assert (res == o.so_far()).all()
 
 
+def test_hybrid_extra_bytes():
+    results = np.empty(1000000, dtype=np.int32)
+    with open(os.path.join(here, 'hybrid')) as f:
+        for i, l in enumerate(f):
+            if i > count // 20:
+                break
+            (data, width, length, res) = eval(l)
+            if length is not None:
+                data = data + b'extra bytes'
+                length += len(b'extra bytes')
+            else:
+                continue
+            i = encoding.Numpy8(np.frombuffer(memoryview(data), dtype=np.uint8))
+            o = encoding.Numpy32(results)
+            encoding.read_rle_bit_packed_hybrid(i, width, length, o)
+            assert (res == o.so_far()[:len(res)]).all()
+            assert i.loc == len(data)
+
+
 def test_read_data():
     with open(os.path.join(here, 'read_data')) as f:
         for i, l in enumerate(f):


### PR DESCRIPTION
Previously, reading of definition levels stopped when there were enough to
satisfy the given row count for the data page in question. It turns out
there can be unused bytes after this - but that the total length of the
definitions block is correctly specified, so the extra bytes can simply
be skipped.

Fixes #74 

