### PR TITLE
Import `tobson`, otherwise it's undefined.

### DIFF
--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -18,6 +18,7 @@ from thriftpy.protocol.exc import TProtocolException
 from .thrift_filetransport import TFileTransport
 from .thrift_structures import parquet_thrift
 from .compression import compress_data, decompress_data
+from .converted_types import tobson
 from . import encoding, api
 from .util import (default_open, default_mkdirs, sep_from_open,
                    ParquetException, thrift_copy, index_like)


### PR DESCRIPTION
Linting tools such as `pyflakes`, `pylint`, or fancy editors would have picked this up.  My apologies for not adding a regression test.  It looks like `tobson` is tested elsewhere.