### PR TITLE
Don't overwrite `has_nulls` when iterating over columns, and be explicit about bool types.

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -697,3 +697,19 @@ def test_empty_dataframe(tempdir):
     assert pf.count == 0
     assert len(out) == 0
     assert (out.columns == df.columns).all()
+
+
+def test_hasnulls_ordering(tempdir):
+    fname = os.path.join(tempdir, 'temp.parq')
+    data = pd.DataFrame({'a': np.random.rand(100),
+                         'b': np.random.rand(100),
+                         'c': np.random.rand(100)})
+    writer.write(fname, data, has_nulls=['a', 'c'])
+
+    r = ParquetFile(fname)
+    assert r.schema[1].name == 'a'
+    assert r.schema[1].repetition_type == 1
+    assert r.schema[2].name == 'b'
+    assert r.schema[2].repetition_type == 0
+    assert r.schema[3].name == 'c'
+    assert r.schema[3].repetition_type == 1

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -590,12 +590,12 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
         else:
             se, type = find_type(data[column], fixed_text=fixed,
                                  object_encoding=oencoding)
+        col_has_nulls = has_nulls
         if has_nulls is None:
             se.repetition_type = type == parquet_thrift.Type.BYTE_ARRAY
-        else:
-            has_nulls = (has_nulls if has_nulls in [True, False]
-                         else column in has_nulls)
-        if has_nulls and data[column].dtype.kind != 'i':
+        elif has_nulls is not True and has_nulls is not False:
+            col_has_nulls = column in has_nulls
+        if col_has_nulls and data[column].dtype.kind != 'i':
             se.repetition_type = parquet_thrift.FieldRepetitionType.OPTIONAL
         fmd.schema.append(se)
         root.num_children += 1


### PR DESCRIPTION
I don't really know what's going on here.  I was trying to understand how one should effectively use `has_nulls=` keyword argument.  I accidentally passed a pandas Series or Index, which I would expect to work just as well as a list, and the `has_nulls in [True, False]` check failed.  Anyway, I noticed that we are iterating over columns, and that we may redefine `has_nulls` inside the loop, thereby changing its value for later columns.  We probably don't want to do that.

As I said, I don't really know what's supposed to go on here, so I'll defer to your judgement.  Sorry again for adding no tests.