### PR TITLE
Missing compression message when using integer

### DIFF
--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -33,7 +33,8 @@ compressions = {k.upper(): v for k, v in compressions.items()}
 decompressions = {k.upper(): v for k, v in decompressions.items()}
 
 rev_map = {getattr(parquet_thrift.CompressionCodec, key): key for key in
-           dir(parquet_thrift.CompressionCodec) if key in compressions}
+           dir(parquet_thrift.CompressionCodec) if key in
+           ['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'SNAPPY', 'LZO', 'BROTLI']}
 
 
 def compress_data(data, algorithm='gzip'):

--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -23,3 +23,10 @@ def test_errors():
 
     assert 'not-an-algorithm' in str(e)
     assert 'gzip' in str(e).lower()
+
+
+def test_not_installed():
+    compressions.pop('BROTLI', None)
+    with pytest.raises(RuntimeError) as e:
+        compress_data(b'123', algorithm=4)
+    assert 'brotli' in str(e.value).lower()


### PR DESCRIPTION
If reading a file, the compression codec is an integer, not a string,
but decoding to string failed if the codec wasn't installed.

Solves
http://stackoverflow.com/questions/42234944/can-python-fastparquet-module-read-in-compressed-parquet-file