### PR TITLE
Fix for failure to pass data to Spark 2

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -18,7 +18,7 @@ from .thrift_structures import parquet_thrift
 from . import core, schema, converted_types, encoding, dataframe
 from .util import (default_open, ParquetException, sep_from_open, val_to_num,
                    ensure_bytes, check_column_names, metadata_from_many,
-                   ex_from_sep)
+                   ex_from_sep, created_by)
 
 
 class ParquetFile(object):
@@ -103,7 +103,7 @@ class ParquetFile(object):
             for chunk in rg.columns:
                 self.group_files.setdefault(i, set()).add(chunk.file_path)
         self.helper = schema.SchemaHelper(self.schema)
-        self.selfmade = self.created_by == "fastparquet-python"
+        self.selfmade = self.created_by.split(' ', 1)[0] == "fastparquet-python"
         self._read_partitions()
         self._dtypes()
 

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -107,6 +107,8 @@ def read_data_page(f, helper, header, metadata, skip_nulls=False,
     else:
         definition_levels, num_nulls = read_def(io_obj, daph, helper, metadata)
 
+    nval = daph.num_values-num_nulls
+
     repetition_levels = read_rep(io_obj, daph, helper, metadata)
     if daph.encoding == parquet_thrift.Encoding.PLAIN:
         width = helper.schema_element(metadata.path_in_schema[-1]).type_length
@@ -131,12 +133,12 @@ def read_data_page(f, helper, header, metadata, skip_nulls=False,
             # length is simply "all data left in this page"
             encoding.read_rle_bit_packed_hybrid(
                         io_obj, bit_width, io_obj.len-io_obj.loc, o=values)
-            values = values.data[:daph.num_values-num_nulls]
+            values = values.data[:nval]
         else:
-            values = np.zeros(daph.num_values-num_nulls, dtype=np.int8)
+            values = np.zeros(nval, dtype=np.int8)
     else:
         raise NotImplementedError('Encoding %s' % daph.encoding)
-    return definition_levels, repetition_levels, values
+    return definition_levels, repetition_levels, values[:nval]
 
 
 def skip_definition_bytes(io_obj, num):

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -162,6 +162,4 @@ def unpack_byte_array(bytes raw_bytes, Py_ssize_t n):
         out[i] = PyBytes_FromStringAndSize(<char *> data, itemlen)
         data += itemlen
 
-    if remaining != 0:
-        raise RuntimeError("invalid input size (corrupted?)")
     return out

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -151,14 +151,14 @@ def unpack_byte_array(bytes raw_bytes, Py_ssize_t n):
         # It is required to check this inside the loop to avoid
         # out of bounds array accesses.
         if remaining < 0:
-            break
+            raise RuntimeError("Ran out of input")
         itemlen = (data[0] + (data[1] << 8) +
                    (data[2] << 16) + (data[3] << 24))
         data += 4
 
         remaining -= itemlen
         if remaining < 0:
-            break
+            raise RuntimeError("Ran out of input")
         out[i] = PyBytes_FromStringAndSize(<char *> data, itemlen)
         data += itemlen
 

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -88,12 +88,12 @@ def test_rle_bp():
 def test_pyspark_roundtrip(tempdir, scheme, row_groups, comp, sql):
     if comp == 'BROTLI':
         pytest.xfail("spark doesn't support BROTLI compression")
-    data = pd.DataFrame({'i32': np.arange(1000, dtype=np.int32),
-                         'i64': np.arange(1000, dtype=np.int64),
-                         'f': np.arange(1000, dtype=np.float64),
+    data = pd.DataFrame({'i32': np.arange(1001, dtype=np.int32),
+                         'i64': np.arange(1001, dtype=np.int64),
+                         'f': np.arange(1001, dtype=np.float64),
                          'bhello': np.random.choice([b'hello', b'you',
-                            b'people'], size=1000).astype("O"),
-                         't': [datetime.datetime.now()]*1000})
+                            b'people'], size=1001).astype("O"),
+                         't': [datetime.datetime.now()]*1001})
 
     data['t'] += pd.to_timedelta('1ns')
     data['hello'] = data.bhello.str.decode('utf8')

--- a/fastparquet/test/test_speedups.py
+++ b/fastparquet/test/test_speedups.py
@@ -113,9 +113,14 @@ def test_unpack_byte_array():
         with pytest.raises(RuntimeError):
             unpack_byte_array(b, n)
 
-    check_invalid_length(packed, len(bytestrings) - 1)
     check_invalid_length(packed, len(bytestrings) + 1)
-    check_invalid_length(packed + b'\x00', len(bytestrings))
-    check_invalid_length(packed + b'\x01\x02\x03\x04', len(bytestrings))
     check_invalid_length(packed[:-1], len(bytestrings))
     check_invalid_length(packed[:-1], len(bytestrings))
+
+    # Extra bytes silently ignored
+    seq = unpack_byte_array(packed, len(bytestrings) - 1)
+    assert seq == bytestrings[:-1]
+    seq = unpack_byte_array(packed + b'\x00', len(bytestrings))
+    assert seq == bytestrings
+    seq = unpack_byte_array(packed + b'\x01\x02\x03\x04', len(bytestrings))
+    assert seq == bytestrings

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -12,7 +12,9 @@ import six
 
 PY2 = six.PY2
 PY3 = six.PY3
-STR_TYPE = six.string_types[0] # 'str' for Python3, 'basestring' for Python2
+STR_TYPE = six.string_types[0]  # 'str' for Python3, 'basestring' for Python2
+created_by = "fastparquet-python version 1.0.0 (build 111)"
+
 
 class ParquetException(Exception):
     """Generic Exception related to unexpected data format when

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -449,7 +449,7 @@ def write_column(f, data, selement, compression=None):
                 num_values=len(data.cat.categories),
                 encoding=parquet_thrift.Encoding.PLAIN)
         bdata = encode['PLAIN'](pd.Series(data.cat.categories), selement)
-        bdata += (16 - (len(bdata) % 8)) * b'\x00'
+        bdata += 8 * b'\x00'
         l0 = len(bdata)
         if compression:
             bdata = compress_data(bdata, compression)
@@ -481,7 +481,7 @@ def write_column(f, data, selement, compression=None):
     start = f.tell()
     bdata = definition_data + repetition_data + encode[encoding](
             data, selement)
-    bdata += (16 - (len(bdata) % 8)) * b'\x00'
+    bdata += 8 * b'\x00'
     try:
         if encoding != 'PLAIN_DICTIONARY' and num_nulls == 0:
             max, min = data.values.max(), data.values.min()


### PR DESCRIPTION
Latest: all tests pass bar one, in which (incredibly) the two row groups get flipped in order by spark, but otherwise are correct. Also, compression=None and compression=UNCOMPRESSED don't necessarily give the right result, but I think this must be a race condition on which partition spark happens to choose first.

Fixes #108 

Edit: Turns out that Spark ignored the metadata file, and loads pieces in arbitrary order.