### PR TITLE
Add categorical info to metadata

### DIFF
--- a/docs/source/details.rst
+++ b/docs/source/details.rst
@@ -22,9 +22,13 @@ category type:
 
     df[col] = df[col].astype('category')
 
-To efficiently load a column as a categorical type, include it in the optional
+Fastparquet will automatically use metadata information to load such columns
+as categorical *if* the data was written by fastparquet.
+
+To efficiently load a column as a categorical type for data from other
+parquet frameworks, include it in the optional
 keyword parameter ``categories``; however it must be encoded as dictionary
-throughout the dataset (as it will, if written by fastparquet).
+throughout the dataset.
 
 .. code-block:: python
 
@@ -39,7 +43,8 @@ be de-referenced on load which is potentially expensive.
 
 Note that before loading, it is not possible to know whether the above condition
 will be met, so the ``dtypes`` attribute of a ``ParquetFile`` will show the
-data type appropriate for the values of column and never ``Category``.
+data type appropriate for the values of column, unless the data originates with
+fastparquet.
 
 Byte Arrays
 -----------

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -536,6 +536,26 @@ def test_many_categories(tempdir, n):
     assert (out.y == df.y).all()
 
 
+def test_autocat(tempdir):
+    tmp = str(tempdir)
+    fn = os.path.join(tmp, "test.parq")
+    data = pd.DataFrame({'o': pd.Categorical(
+        np.random.choice(['hello', 'world'], size=1000))})
+    write(fn, data)
+    pf = ParquetFile(fn)
+    assert 'o' in pf.categories
+    assert pf.categories['o'] == 2
+    assert pf.dtypes['o'] == 'category'
+    out = pf.to_pandas()
+    assert out.dtypes['o'] == 'category'
+    out = pf.to_pandas(categories={})
+    assert str(out.dtypes['o']) != 'category'
+    out = pf.to_pandas(categories=['o'])
+    assert out.dtypes['o'] == 'category'
+    out = pf.to_pandas(categories={'o': 2})
+    assert out.dtypes['o'] == 'category'
+
+
 @pytest.mark.parametrize('row_groups', ([0], [0, 2]))
 @pytest.mark.parametrize('dirs', (['', ''], ['cat=1', 'cat=2']))
 def test_merge(tempdir, dirs, row_groups):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -594,11 +594,15 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
     root = parquet_thrift.SchemaElement(name='schema',
                                         num_children=0)
 
+    cats = parquet_thrift.KeyValue()
+    cats.key = 'fastparquet.cats'
+    catstruct = {}
     fmd = parquet_thrift.FileMetaData(num_rows=len(data),
                                       schema=[root],
                                       version=1,
                                       created_by=created_by,
-                                      row_groups=[])
+                                      row_groups=[],
+                                      key_value_metadata=[cats])
 
     object_encoding = object_encoding or {}
     for column in data.columns:
@@ -611,6 +615,7 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
             se, type = find_type(data[column].cat.categories,
                                  fixed_text=fixed, object_encoding=oencoding)
             se.name = column
+            catstruct[column] = len(data[column].cat.categories)
         else:
             se, type = find_type(data[column], fixed_text=fixed,
                                  object_encoding=oencoding, times=times)
@@ -624,6 +629,7 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
             se.repetition_type = parquet_thrift.FieldRepetitionType.OPTIONAL
         fmd.schema.append(se)
         root.num_children += 1
+    cats.value = json.dumps(catstruct)
     return fmd
 
 


### PR DESCRIPTION
Now, to_pandas() et al will automatically use categoricals for
data written by fastparquet. Previous behaviour remains for files
from other parquet writers.

To *not* load as categorical for fastparquet-written data, use
to_pandas({}), to_pandas([])...

Fixes #111 