### PR TITLE
ENH added lossy RICE compression of float columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *.dll
 fastparquet/speedups.c
+fastparquet/quantize/_quantize.c
 .coverage
 cover
 build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ recursive-include fastparquet *.py
 recursive-include fastparquet *.pyx
 recursive-include docs *.rst
 
+include fastparquet/rice/rice.h
+include fastparquet/rice/rice.c
+
 include setup.py
 include README.rst
 include LICENSE

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -139,6 +139,8 @@ def read_data_page(f, helper, header, metadata, skip_nulls=False,
             values = values.data[:nval]
         else:
             values = np.zeros(nval, dtype=np.int8)
+    elif daph.encoding == parquet_thrift.Encoding.LOSSY_RICE:
+        values = encoding.read_lossy_rice(raw_bytes[io_obj.loc:])
     else:
         raise NotImplementedError('Encoding %s' % daph.encoding)
     return definition_levels, repetition_levels, values[:nval]

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -13,6 +13,7 @@ import os
 import struct
 import sys
 
+from . import quantize
 from .speedups import unpack_byte_array
 from .thrift_structures import parquet_thrift
 from .util import byte_buffer
@@ -52,6 +53,9 @@ def read_plain(raw_bytes, type_, count, width=0):
             return np.array([raw_bytes], dtype='O')
         else:
             raise
+
+
+read_lossy_rice = quantize.dequantize_and_decompress
 
 
 @numba.jit(nogil=True)

--- a/fastparquet/parquet.thrift
+++ b/fastparquet/parquet.thrift
@@ -315,7 +315,7 @@ enum Encoding {
 
   /** Custom lossy rice encoding
    */
-  LOSSY_RICE = 9;
+  LOSSY_RICE = 19850410;
 }
 
 /**

--- a/fastparquet/parquet.thrift
+++ b/fastparquet/parquet.thrift
@@ -312,6 +312,10 @@ enum Encoding {
   /** Dictionary encoding: the ids are encoded using the RLE encoding
    */
   RLE_DICTIONARY = 8;
+
+  /** Custom lossy rice encoding
+   */
+  LOSSY_RICE = 9;
 }
 
 /**
@@ -571,4 +575,3 @@ struct FileMetaData {
    **/
   6: optional string created_by
 }
-

--- a/fastparquet/quantize/__init__.py
+++ b/fastparquet/quantize/__init__.py
@@ -1,0 +1,4 @@
+from ._quantize import (quantize_and_compress_float32,
+                        quantize_and_compress_float64,
+                        dequantize_and_decompress,
+                        FloatQuantizationError)

--- a/fastparquet/quantize/_quantize.pyx
+++ b/fastparquet/quantize/_quantize.pyx
@@ -1,0 +1,276 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+from libc.stdlib cimport malloc, free, realloc
+from libc.math cimport isnan, NAN
+
+np.import_array()
+
+ctypedef np.float32_t DTYPE_FLOAT32
+ctypedef np.float64_t DTYPE_FLOAT64
+ctypedef np.npy_intp DTYPE_NPY_INTP
+
+cdef extern from "rice.h" nogil:
+    int rcomp(int *input, int nx, unsigned char *buf, int maxbuflen, int nblock)
+    int rdecomp(unsigned char *buf, int buflen, int *output, int nx, int nblock)
+    int NINT(double x)
+
+cdef extern from "numpy/arrayobject.h":
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+
+cdef extern from "Python.h":
+    object PyBytes_FromStringAndSize(const char *v, Py_ssize_t len)
+    char *PyBytes_AsString(object o)
+
+RICE_MESSAGES = {-1: "end of buffer encountered!",
+                 -2: "out of memory!"}
+
+
+class FloatQuantizationError(Exception):
+    def __init__(self, msg=None):
+        super().__init__(self, msg)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef quantize_and_compress_float32(float [::1] data,
+                                    double scale,
+                                    double zero_point,
+                                    long seed,
+                                    long n_dithers=10000,
+                                    int blocksize=32):
+    """
+    Perform float quantization and then rice compression on float 32 data.
+    """
+    cdef:
+        int n_data = data.size
+        int max_buff_len = data.size * 4
+        int *idata;
+        unsigned char *buff
+        unsigned char *c
+        double *dbuff
+        long *lbuff
+        int *head
+        int blen
+        int i
+        int dloc = 0
+        double [:] dithers
+
+    rng = np.random.RandomState(seed=seed)
+    dithers = rng.uniform(size=n_dithers)
+
+    with nogil:
+        idata = <int*>malloc(n_data * sizeof(int))
+        buff = <unsigned char*>malloc(
+            max_buff_len * sizeof(unsigned char) + 2 * sizeof(double) + 3 * sizeof(long) + 8)
+        dbuff = <double*>buff
+        lbuff = <long*>(buff + 16)
+        head = <int*>(buff + 40)
+        c = <unsigned char*>(buff + 48)
+        dbuff[0] = scale
+        dbuff[1] = zero_point
+        lbuff[0] = seed
+        lbuff[1] = n_dithers
+        lbuff[2] = 4
+        head[0] = n_data
+        head[1] = blocksize
+
+        for i from 0 <= i < n_data by 1:
+            if data[i] == 0.0:
+                idata[i] = -2147483645
+            elif data[i] == 1.0:
+                idata[i] = -2147483646
+            elif isnan(data[i]):
+                idata[i] = -2147483647
+            else:
+                idata[i] = NINT(((<double> data[i]) - zero_point) / scale + dithers[dloc] - 0.5)
+            dloc += 1
+            if dloc >= n_dithers:
+                dloc = 0
+
+        blen = rcomp(idata, n_data, c, max_buff_len, blocksize)
+        free(idata)
+
+    if blen <= 0:
+        free(buff)
+        raise FloatQuantizationError("compression: " + RICE_MESSAGES[blen])
+
+    with nogil:
+        buff = <unsigned char*>realloc(buff, blen + 48)
+
+    return PyBytes_FromStringAndSize(<char *>buff, blen + 48)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef quantize_and_compress_float64(double [::1] data,
+                                    double scale,
+                                    double zero_point,
+                                    long seed,
+                                    long n_dithers=10000,
+                                    int blocksize=32):
+    """
+    Perform float quantization and then rice compression on float 64 data.
+    """
+    cdef:
+        int n_data = data.size
+        int max_buff_len = data.size * 4
+        int *idata;
+        unsigned char *buff
+        unsigned char *c
+        double *dbuff
+        long *lbuff
+        int *head
+        int blen
+        int i
+        int dloc = 0
+        double [:] dithers
+
+    rng = np.random.RandomState(seed=seed)
+    dithers = rng.uniform(size=n_dithers)
+
+    with nogil:
+        idata = <int*>malloc(n_data * sizeof(int))
+        buff = <unsigned char*>malloc(
+            max_buff_len * sizeof(unsigned char) + 2 * sizeof(double) + 3 * sizeof(long) + 8)
+        dbuff = <double*>buff
+        lbuff = <long*>(buff + 16)
+        head = <int*>(buff + 40)
+        c = <unsigned char*>(buff + 48)
+        dbuff[0] = scale
+        dbuff[1] = zero_point
+        lbuff[0] = seed
+        lbuff[1] = n_dithers
+        lbuff[2] = 8
+        head[0] = n_data
+        head[1] = blocksize
+
+        for i from 0 <= i < n_data by 1:
+            if data[i] == 0.0:
+                idata[i] = -2147483645
+            elif data[i] == 1.0:
+                idata[i] = -2147483646
+            elif isnan(data[i]):
+                idata[i] = -2147483647
+            else:
+                idata[i] = NINT((data[i] - zero_point) / scale + dithers[dloc] - 0.5)
+            dloc += 1
+            if dloc >= n_dithers:
+                dloc = 0
+
+        blen = rcomp(idata, n_data, c, max_buff_len, blocksize)
+        free(idata)
+
+    if blen <= 0:
+        free(buff)
+        raise FloatQuantizationError("compression: " + RICE_MESSAGES[blen])
+
+    with nogil:
+        buff = <unsigned char*>realloc(buff, blen + 48)
+
+    return PyBytes_FromStringAndSize(<char *>buff, blen + 48)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef dequantize_and_decompress(bytes _buff):
+    """
+    Perform float de-quanization and rice decompression to float 32 data.
+    """
+    cdef:
+        double scale
+        double zero_point
+        long seed
+        long n_dithers
+        long itemsize
+        int n_data
+        int blocksize
+        DTYPE_NPY_INTP n_data_intp
+
+        unsigned char *c
+        unsigned char *buff
+        int ret
+        void *data
+        float *fdata
+        double *ddata
+        int *idata
+        int buff_len
+        int i
+        int dloc = 0
+        double [:] dithers
+        np.ndarray[DTYPE_FLOAT32, ndim=1] farr
+        np.ndarray[DTYPE_FLOAT64, ndim=1] darr
+
+    buff = <unsigned char*>PyBytes_AsString(_buff)
+    buff_len = len(_buff) - 48
+
+    with nogil:
+        dbuff = <double*>buff
+        lbuff = <long*>(buff + 16)
+        head = <int*>(buff + 40)
+        c = <unsigned char*>(buff + 48)
+        scale = dbuff[0]
+        zero_point = dbuff[1]
+        seed = lbuff[0]
+        n_dithers = lbuff[1]
+        itemsize = lbuff[2]
+        n_data = head[0]
+        blocksize = head[1]
+
+        if itemsize == 4:
+            data = <void*>malloc(n_data * sizeof(float))
+            fdata = <float*>data
+        else:
+            data = <void*>malloc(n_data * sizeof(double))
+            ddata = <double*>data
+
+        idata = <int*>malloc(n_data * sizeof(int))
+        ret = rdecomp(c, buff_len, idata, n_data, blocksize)
+
+    if ret == 0:
+        rng = np.random.RandomState(seed=seed)
+        dithers = rng.uniform(size=n_dithers)
+    else:
+        free(idata)
+        free(data)
+        raise FloatQuantizationError("decompression: " + RICE_MESSAGES[ret])
+
+    with nogil:
+        if itemsize == 4:
+            for i from 0 <= i < n_data by 1:
+                if idata[i] == -2147483645:
+                    fdata[i] = 0.0
+                elif idata[i] == -2147483646:
+                    fdata[i] = 1.0
+                elif idata[i] == -2147483647:
+                    fdata[i] = NAN
+                else:
+                    fdata[i] = <float>(((idata[i] - dithers[dloc] + 0.5) * scale) + zero_point)
+                dloc += 1
+                if dloc >= n_dithers:
+                    dloc = 0
+        else:
+            for i from 0 <= i < n_data by 1:
+                if idata[i] == -2147483645:
+                    ddata[i] = 0.0
+                elif idata[i] == -2147483646:
+                    ddata[i] = 1.0
+                elif idata[i] == -2147483647:
+                    ddata[i] = NAN
+                else:
+                    ddata[i] = <double>(((idata[i] - dithers[dloc] + 0.5) * scale) + zero_point)
+                dloc += 1
+                if dloc >= n_dithers:
+                    dloc = 0
+
+        free(idata)
+
+    n_data_intp = n_data
+    if itemsize == 4:
+        farr = np.PyArray_SimpleNewFromData(1, &n_data_intp, np.NPY_FLOAT32, data)
+        PyArray_ENABLEFLAGS(farr, np.NPY_OWNDATA)
+        return farr
+    else:
+        darr = np.PyArray_SimpleNewFromData(1, &n_data_intp, np.NPY_FLOAT64, data)
+        PyArray_ENABLEFLAGS(darr, np.NPY_OWNDATA)
+        return darr

--- a/fastparquet/quantize/rice.c
+++ b/fastparquet/quantize/rice.c
@@ -1,0 +1,598 @@
+/*
+File From: http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3410.tar.gz
+Minor modifications by M. Becker, 2017.
+Original License:
+
+Copyright (Unpublished--all rights reserved under the copyright laws of
+the United States), U.S. Government as represented by the Administrator
+of the National Aeronautics and Space Administration.  No copyright is
+claimed in the United States under Title 17, U.S. Code.
+
+Permission to freely use, copy, modify, and distribute this software
+and its documentation without fee is hereby granted, provided that this
+copyright notice and disclaimer of warranty appears in all copies.
+
+DISCLAIMER:
+
+THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND,
+EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO,
+ANY WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, AND FREEDOM FROM INFRINGEMENT, AND ANY WARRANTY THAT THE
+DOCUMENTATION WILL CONFORM TO THE SOFTWARE, OR ANY WARRANTY THAT THE
+SOFTWARE WILL BE ERROR FREE.  IN NO EVENT SHALL NASA BE LIABLE FOR ANY
+DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN ANY WAY
+CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+CONTRACT, TORT , OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY
+PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED
+FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR
+SERVICES PROVIDED HEREUNDER.
+
+  The following code was written by Richard White at STScI and made
+  available for use in CFITSIO in July 1999.  These routines were
+  originally contained in 2 source files: rcomp.c and rdecomp.c,
+  and the 'include' file now called ricecomp.h was originally called buffer.h.
+*/
+
+/*----------------------------------------------------------*/
+/*                                                          */
+/*    START OF SOURCE FILE ORIGINALLY CALLED rcomp.c        */
+/*                                                          */
+/*----------------------------------------------------------*/
+/* @(#) rcomp.c 1.5 99/03/01 12:40:27 */
+/* rcomp.c    Compress image line using
+ *        (1) Difference of adjacent pixels
+ *        (2) Rice algorithm coding
+ *
+ * Returns number of bytes written to code buffer or
+ * -1 on failure
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define RICE_END_OF_BUFFER_ERROR  -1
+#define RICE_OUT_OF_MEMORY_ERROR  -2
+
+/*
+ * nonzero_count is lookup table giving number of bits in 8-bit values not including
+ * leading zeros used in fits_rdecomp, fits_rdecomp_short and fits_rdecomp_byte
+ */
+static const int nonzero_count[256] = {
+  0,
+  1,
+  2, 2,
+  3, 3, 3, 3,
+  4, 4, 4, 4, 4, 4, 4, 4,
+  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+  6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+  6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+  7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8};
+
+typedef unsigned char Buffer_t;
+
+typedef struct {
+  int bitbuffer;      // bit buffer
+  int bits_to_go;     // bits to go in buffer
+  Buffer_t *start;    // start of buffer
+  Buffer_t *current;  // current position in buffer
+  Buffer_t *end;      // end of buffer
+} Buffer;
+
+#define putcbuf(c,mf)     ((*(mf->current)++ = c), 0)
+
+static void start_outputing_bits(Buffer *buffer);
+static int done_outputing_bits(Buffer *buffer);
+static int output_nbits(Buffer *buffer, int bits, int n);
+
+/*  only used for diagnoistics
+    static int case1, case2, case3;
+    int fits_get_case(int *c1, int*c2, int*c3) {
+
+    *c1 = case1;
+    *c2 = case2;
+    *c3 = case3;
+    return(0);
+    }
+*/
+
+/* this routine used to be called 'rcomp'  (WDP)  */
+/*---------------------------------------------------------------------------*/
+
+int rcomp(int a[],          // input array
+          int nx,           // number of input pixels
+          unsigned char *c, // output buffer
+          int clen,         // max length of output
+          int nblock)       // coding block size
+{
+  Buffer bufmem, *buffer = &bufmem;
+  /* int bsize;  */
+  int i, j, thisblock;
+  int lastpix, nextpix, pdiff;
+  int v, fs, fsmask, top, fsmax, fsbits, bbits;
+  int lbitbuffer, lbits_to_go;
+  unsigned int psum;
+  double pixelsum, dpsum;
+  unsigned int *diff;
+
+  /*
+   * Original size of each pixel (bsize, bytes) and coding block
+   * size (nblock, pixels)
+   * Could make bsize a parameter to allow more efficient
+   * compression of short & byte images.
+   */
+  /*    bsize = 4;   */
+
+  /*    nblock = 32; now an input parameter*/
+  /*
+   * From bsize derive:
+   * FSBITS = # bits required to store FS
+   * FSMAX = maximum value for FS
+   * BBITS = bits/pixel for direct coding
+   */
+
+  /*
+    switch (bsize) {
+    case 1:
+    fsbits = 3;
+    fsmax = 6;
+    break;
+    case 2:
+    fsbits = 4;
+    fsmax = 14;
+    break;
+    case 4:
+    fsbits = 5;
+    fsmax = 25;
+    break;
+    default:
+    FFPMSG("rdecomp: bsize must be 1, 2, or 4 bytes");
+    return(-1);
+    }
+  */
+
+  /* move out of switch block, to tweak performance */
+  fsbits = 5;
+  fsmax = 25;
+
+  bbits = 1<<fsbits;
+
+  /*
+   * Set up buffer pointers
+   */
+  buffer->start = c;
+  buffer->current = c;
+  buffer->end = c+clen;
+  buffer->bits_to_go = 8;
+  /*
+   * array for differences mapped to non-negative values
+   */
+  diff = (unsigned int *) malloc(nblock*sizeof(unsigned int));
+  if (diff == (unsigned int *) NULL) {
+    return RICE_OUT_OF_MEMORY_ERROR;
+  }
+  /*
+   * Code in blocks of nblock pixels
+   */
+  start_outputing_bits(buffer);
+
+  /* write out first int value to the first 4 bytes of the buffer */
+  if (output_nbits(buffer, a[0], 32) == EOF) {
+    free(diff);
+    return RICE_END_OF_BUFFER_ERROR;
+  }
+
+  lastpix = a[0];  /* the first difference will always be zero */
+
+  thisblock = nblock;
+  for (i=0; i<nx; i += nblock) {
+    /* last block may be shorter */
+    if (nx-i < nblock) thisblock = nx-i;
+    /*
+     * Compute differences of adjacent pixels and map them to unsigned values.
+     * Note that this may overflow the integer variables -- that's
+     * OK, because we can recover when decompressing.  If we were
+     * compressing shorts or bytes, would want to do this arithmetic
+     * with short/byte working variables (though diff will still be
+     * passed as an int.)
+     *
+     * compute sum of mapped pixel values at same time
+     * use double precision for sum to allow 32-bit integer inputs
+     */
+    pixelsum = 0.0;
+    for (j=0; j<thisblock; j++) {
+      nextpix = a[i+j];
+      pdiff = nextpix - lastpix;
+      diff[j] = (unsigned int) ((pdiff<0) ? ~(pdiff<<1) : (pdiff<<1));
+      pixelsum += diff[j];
+      lastpix = nextpix;
+    }
+
+    /*
+     * compute number of bits to split from sum
+     */
+    dpsum = (pixelsum - (thisblock/2) - 1)/thisblock;
+    if (dpsum < 0) dpsum = 0.0;
+    psum = ((unsigned int) dpsum ) >> 1;
+    for (fs = 0; psum>0; fs++) psum >>= 1;
+
+    /*
+     * write the codes
+     * fsbits ID bits used to indicate split level
+     */
+    if (fs >= fsmax) {
+      /* Special high entropy case when FS >= fsmax
+       * Just write pixel difference values directly, no Rice coding at all.
+       */
+      if (output_nbits(buffer, fsmax+1, fsbits) == EOF) {
+        free(diff);
+        return RICE_END_OF_BUFFER_ERROR;
+      }
+      for (j=0; j<thisblock; j++) {
+        if (output_nbits(buffer, diff[j], bbits) == EOF) {
+          free(diff);
+          return RICE_END_OF_BUFFER_ERROR;
+        }
+      }
+    } else if (fs == 0 && pixelsum == 0) {
+      /*
+       * special low entropy case when FS = 0 and pixelsum=0 (all
+       * pixels in block are zero.)
+       * Output a 0 and return
+       */
+      if (output_nbits(buffer, 0, fsbits) == EOF) {
+        free(diff);
+        return RICE_END_OF_BUFFER_ERROR;
+      }
+    } else {
+      /* normal case: not either very high or very low entropy */
+      if (output_nbits(buffer, fs+1, fsbits) == EOF) {
+        free(diff);
+        return RICE_END_OF_BUFFER_ERROR;
+      }
+      fsmask = (1<<fs) - 1;
+      /*
+       * local copies of bit buffer to improve optimization
+       */
+      lbitbuffer = buffer->bitbuffer;
+      lbits_to_go = buffer->bits_to_go;
+      for (j=0; j<thisblock; j++) {
+        v = diff[j];
+        top = v >> fs;
+        /*
+         * top is coded by top zeros + 1
+         */
+        if (lbits_to_go >= top+1) {
+      lbitbuffer <<= top+1;
+      lbitbuffer |= 1;
+      lbits_to_go -= top+1;
+        } else {
+      lbitbuffer <<= lbits_to_go;
+      putcbuf(lbitbuffer & 0xff,buffer);
+
+      for (top -= lbits_to_go; top>=8; top -= 8) {
+            putcbuf(0, buffer);
+      }
+      lbitbuffer = 1;
+      lbits_to_go = 7-top;
+        }
+        /*
+         * bottom FS bits are written without coding
+         * code is output_nbits, moved into this routine to reduce overheads
+         * This code potentially breaks if FS>24, so I am limiting
+         * FS to 24 by choice of FSMAX above.
+         */
+        if (fs > 0) {
+      lbitbuffer <<= fs;
+      lbitbuffer |= v & fsmask;
+      lbits_to_go -= fs;
+      while (lbits_to_go <= 0) {
+            putcbuf((lbitbuffer>>(-lbits_to_go)) & 0xff,buffer);
+            lbits_to_go += 8;
+      }
+        }
+      }
+
+      /* check if overflowed output buffer */
+      if (buffer->current > buffer->end) {
+        free(diff);
+        return RICE_END_OF_BUFFER_ERROR;
+      }
+      buffer->bitbuffer = lbitbuffer;
+      buffer->bits_to_go = lbits_to_go;
+    }
+  }
+  done_outputing_bits(buffer);
+  free(diff);
+  /*
+   * return number of bytes used
+   */
+  return(buffer->current - buffer->start);
+}
+
+/*---------------------------------------------------------------------------*/
+/* bit_output.c
+ *
+ * Bit output routines
+ * Procedures return zero on success, EOF on end-of-buffer
+ *
+ * Programmer: R. White     Date: 20 July 1998
+ */
+
+/* Initialize for bit output */
+
+static void start_outputing_bits(Buffer *buffer)
+{
+  /*
+   * Buffer is empty to start with
+   */
+  buffer->bitbuffer = 0;
+  buffer->bits_to_go = 8;
+}
+
+
+/*---------------------------------------------------------------------------*/
+/* Output N bits (N must be <= 32) */
+
+static int output_nbits(Buffer *buffer, int bits, int n)
+{
+  /* local copies */
+  int lbitbuffer;
+  int lbits_to_go;
+  /* AND mask for the right-most n bits */
+  static unsigned int mask[33] =
+    {0,
+     0x1,       0x3,       0x7,       0xf,       0x1f,       0x3f,       0x7f,       0xff,
+     0x1ff,     0x3ff,     0x7ff,     0xfff,     0x1fff,     0x3fff,     0x7fff,     0xffff,
+     0x1ffff,   0x3ffff,   0x7ffff,   0xfffff,   0x1fffff,   0x3fffff,   0x7fffff,   0xffffff,
+     0x1ffffff, 0x3ffffff, 0x7ffffff, 0xfffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff};
+
+  /*
+   * insert bits at end of bitbuffer
+   */
+  lbitbuffer = buffer->bitbuffer;
+  lbits_to_go = buffer->bits_to_go;
+  if (lbits_to_go+n > 32) {
+    /*
+     * special case for large n: put out the top lbits_to_go bits first
+     * note that 0 < lbits_to_go <= 8
+     */
+    lbitbuffer <<= lbits_to_go;
+/*    lbitbuffer |= (bits>>(n-lbits_to_go)) & ((1<<lbits_to_go)-1); */
+    lbitbuffer |= (bits>>(n-lbits_to_go)) & *(mask+lbits_to_go);
+    putcbuf(lbitbuffer & 0xff,buffer);
+    n -= lbits_to_go;
+    lbits_to_go = 8;
+  }
+  lbitbuffer <<= n;
+  /*    lbitbuffer |= ( bits & ((1<<n)-1) ); */
+  lbitbuffer |= ( bits & *(mask+n) );
+  lbits_to_go -= n;
+  while (lbits_to_go <= 0) {
+    /*
+     * bitbuffer full, put out top 8 bits
+     */
+    putcbuf((lbitbuffer>>(-lbits_to_go)) & 0xff,buffer);
+    lbits_to_go += 8;
+  }
+  buffer->bitbuffer = lbitbuffer;
+  buffer->bits_to_go = lbits_to_go;
+  return(0);
+}
+
+/*---------------------------------------------------------------------------*/
+/* Flush out the last bits */
+
+static int done_outputing_bits(Buffer *buffer)
+{
+  if(buffer->bits_to_go < 8) {
+    putcbuf(buffer->bitbuffer<<buffer->bits_to_go,buffer);
+
+    /*    if (putcbuf(buffer->bitbuffer<<buffer->bits_to_go,buffer) == EOF)
+      return(EOF);
+    */
+  }
+  return(0);
+}
+
+/*---------------------------------------------------------------------------*/
+/*----------------------------------------------------------*/
+/*                                                          */
+/*    START OF SOURCE FILE ORIGINALLY CALLED rdecomp.c      */
+/*                                                          */
+/*----------------------------------------------------------*/
+
+/* @(#) rdecomp.c 1.4 99/03/01 12:38:41 */
+/* rdecomp.c    Decompress image line using
+ *        (1) Difference of adjacent pixels
+ *        (2) Rice algorithm coding
+ *
+ * Returns 0 on success or 1 on failure
+ */
+
+/*    moved these 'includes' to the beginning of the file (WDP)
+#include <stdio.h>
+#include <stdlib.h>
+*/
+
+/*---------------------------------------------------------------------------*/
+/* this routine used to be called 'rdecomp'  (WDP)  */
+
+int rdecomp (unsigned char *c,     // input buffer
+             int clen,             // length of input
+             unsigned int array[], // output array
+             int nx,               // number of output pixels
+             int nblock)           // coding block size
+{
+  /* int bsize;  */
+  int i, k, imax;
+  int nbits, nzero, fs;
+  unsigned char *cend, bytevalue;
+  unsigned int b, diff, lastpix;
+  int fsmax, fsbits, bbits;
+  extern const int nonzero_count[];
+
+  /*
+   * Original size of each pixel (bsize, bytes) and coding block
+   * size (nblock, pixels)
+   * Could make bsize a parameter to allow more efficient
+   * compression of short & byte images.
+   */
+  /*    bsize = 4; */
+
+  /*    nblock = 32; now an input parameter */
+  /*
+   * From bsize derive:
+   * FSBITS = # bits required to store FS
+   * FSMAX = maximum value for FS
+   * BBITS = bits/pixel for direct coding
+   */
+
+  /*
+    switch (bsize) {
+    case 1:
+    fsbits = 3;
+    fsmax = 6;
+    break;
+    case 2:
+    fsbits = 4;
+    fsmax = 14;
+    break;
+    case 4:
+    fsbits = 5;
+    fsmax = 25;
+    break;
+    default:
+    FFPMSG("rdecomp: bsize must be 1, 2, or 4 bytes");
+    return 1;
+    }
+*/
+
+  /* move out of switch block, to tweak performance */
+  fsbits = 5;
+  fsmax = 25;
+
+  bbits = 1<<fsbits;
+
+  /*
+   * Decode in blocks of nblock pixels
+   */
+
+  /* first 4 bytes of input buffer contain the value of the first */
+  /* 4 byte integer value, without any encoding */
+
+  lastpix = 0;
+  bytevalue = c[0];
+  lastpix = lastpix | (bytevalue<<24);
+  bytevalue = c[1];
+  lastpix = lastpix | (bytevalue<<16);
+  bytevalue = c[2];
+  lastpix = lastpix | (bytevalue<<8);
+  bytevalue = c[3];
+  lastpix = lastpix | bytevalue;
+
+  c += 4;
+  cend = c + clen - 4;
+
+  b = *c++;            /* bit buffer            */
+  nbits = 8;            /* number of bits remaining in b    */
+  for (i = 0; i<nx; ) {
+    /* get the FS value from first fsbits */
+    nbits -= fsbits;
+    while (nbits < 0) {
+      b = (b<<8) | (*c++);
+      nbits += 8;
+    }
+    fs = (b >> nbits) - 1;
+
+    b &= (1<<nbits)-1;
+    /* loop over the next block */
+    imax = i + nblock;
+    if (imax > nx) imax = nx;
+    if (fs<0) {
+      /* low-entropy case, all zero differences */
+      for ( ; i<imax; i++) array[i] = lastpix;
+    } else if (fs==fsmax) {
+      /* high-entropy case, directly coded pixel values */
+      for ( ; i<imax; i++) {
+        k = bbits - nbits;
+        diff = b<<k;
+        for (k -= 8; k >= 0; k -= 8) {
+      b = *c++;
+      diff |= b<<k;
+        }
+        if (nbits>0) {
+      b = *c++;
+      diff |= b>>(-k);
+      b &= (1<<nbits)-1;
+        } else {
+      b = 0;
+        }
+        /*
+         * undo mapping and differencing
+         * Note that some of these operations will overflow the
+         * unsigned int arithmetic -- that's OK, it all works
+         * out to give the right answers in the output file.
+         */
+        if ((diff & 1) == 0) {
+      diff = diff>>1;
+        } else {
+      diff = ~(diff>>1);
+        }
+        array[i] = diff+lastpix;
+        lastpix = array[i];
+      }
+    } else {
+      /* normal case, Rice coding */
+      for ( ; i<imax; i++) {
+        /* count number of leading zeros */
+        while (b == 0) {
+      nbits += 8;
+      b = *c++;
+        }
+        nzero = nbits - nonzero_count[b];
+        nbits -= nzero+1;
+        /* flip the leading one-bit */
+        b ^= 1<<nbits;
+        /* get the FS trailing bits */
+        nbits -= fs;
+        while (nbits < 0) {
+      b = (b<<8) | (*c++);
+      nbits += 8;
+        }
+        diff = (nzero<<fs) | (b>>nbits);
+        b &= (1<<nbits)-1;
+
+        /* undo mapping and differencing */
+        if ((diff & 1) == 0) {
+      diff = diff>>1;
+        } else {
+      diff = ~(diff>>1);
+        }
+        array[i] = diff+lastpix;
+        lastpix = array[i];
+      }
+    }
+    if (c > cend) {
+      return RICE_END_OF_BUFFER_ERROR;
+    }
+  }
+  // No reason to raise this error.
+  // if (c < cend) {
+  //   return RICE_UNUSED_BYTES_WARNING;
+  // }
+  return 0;
+}

--- a/fastparquet/quantize/rice.h
+++ b/fastparquet/quantize/rice.h
@@ -1,0 +1,73 @@
+/*
+File From: https://github.com/tclarke/ricecomp-cfitsio-python
+Minor modifications by M. Becker, 2017.
+Original License:
+
+Copyright (c) 2014, Trevor R.H. Clarke
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef __RICE__
+#define __RICE__
+
+extern int rcomp(int a[], int nx, unsigned char *c, int clen, int nblock);
+extern int rdecomp(unsigned char *c, int clen, int array[], int nx, int nblock);
+
+/*
+nearest integer from cfitsio
+Original License:
+
+Copyright (Unpublished--all rights reserved under the copyright laws of
+the United States), U.S. Government as represented by the Administrator
+of the National Aeronautics and Space Administration.  No copyright is
+claimed in the United States under Title 17, U.S. Code.
+
+Permission to freely use, copy, modify, and distribute this software
+and its documentation without fee is hereby granted, provided that this
+copyright notice and disclaimer of warranty appears in all copies.
+
+DISCLAIMER:
+
+THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND,
+EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO,
+ANY WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, AND FREEDOM FROM INFRINGEMENT, AND ANY WARRANTY THAT THE
+DOCUMENTATION WILL CONFORM TO THE SOFTWARE, OR ANY WARRANTY THAT THE
+SOFTWARE WILL BE ERROR FREE.  IN NO EVENT SHALL NASA BE LIABLE FOR ANY
+DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN ANY WAY
+CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
+CONTRACT, TORT , OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY
+PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED
+FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR
+SERVICES PROVIDED HEREUNDER.
+
+  The following code was written by Richard White at STScI and made
+  available for use in CFITSIO in July 1999.  These routines were
+  originally contained in 2 source files: rcomp.c and rdecomp.c,
+  and the 'include' file now called ricecomp.h was originally called buffer.h.
+*/
+#define NINT(x)  ((x >= 0.) ? (int) (x + 0.5) : (int) (x - 0.5))
+
+#endif /* __RICE__ */

--- a/fastparquet/quantize/tests/test_quantize.py
+++ b/fastparquet/quantize/tests/test_quantize.py
@@ -1,6 +1,7 @@
 import numpy as np
 from fastparquet import quantize
 
+
 def test_quantize_float32():
     seed = 2454389
     rng = np.random.RandomState(seed=seed)
@@ -10,6 +11,7 @@ def test_quantize_float32():
     std = np.std(data - check_data)
     assert std < 0.05, "RICE float quantization and compression for float 32 is broken!"
 
+
 def test_quantize_float64():
     seed = 2454389
     rng = np.random.RandomState(seed=seed)
@@ -18,3 +20,33 @@ def test_quantize_float64():
     check_data = quantize.dequantize_and_decompress(buff)
     std = np.std(data - check_data)
     assert std < 0.05, "RICE float quantization and compression for float 64 is broken!"
+
+
+def test_seeding_float32():
+    seed = 2454389
+    rng = np.random.RandomState(seed=seed)
+    data = rng.normal(size=100000).astype(np.float32)
+
+    buff = quantize.quantize_and_compress_float32(data, 0.1, 0.0, seed=1234)
+    check_data = quantize.dequantize_and_decompress(buff)
+
+    buff2 = quantize.quantize_and_compress_float32(data, 0.1, 0.0, seed=1234)
+    check_data2 = quantize.dequantize_and_decompress(buff2)
+
+    assert np.array_equal(check_data, check_data2), (
+        "RICE float quantization is not deterministic for float 32!")
+
+
+def test_seeding_float64():
+    seed = 2454389
+    rng = np.random.RandomState(seed=seed)
+    data = rng.normal(size=100000).astype(np.float64)
+
+    buff = quantize.quantize_and_compress_float64(data, 0.1, 0.0, seed=1234)
+    check_data = quantize.dequantize_and_decompress(buff)
+
+    buff2 = quantize.quantize_and_compress_float64(data, 0.1, 0.0, seed=1234)
+    check_data2 = quantize.dequantize_and_decompress(buff2)
+
+    assert np.array_equal(check_data, check_data2), (
+        "RICE float quantization is not deterministic for float 64!")

--- a/fastparquet/quantize/tests/test_quantize.py
+++ b/fastparquet/quantize/tests/test_quantize.py
@@ -10,7 +10,7 @@ def test_quantize_float32():
     std = np.std(data - check_data)
     assert std < 0.05, "RICE float quantization and compression for float 32 is broken!"
 
-def test_quantize_float32():
+def test_quantize_float64():
     seed = 2454389
     rng = np.random.RandomState(seed=seed)
     data = rng.normal(size=100000).astype(np.float64)

--- a/fastparquet/quantize/tests/test_quantize.py
+++ b/fastparquet/quantize/tests/test_quantize.py
@@ -1,0 +1,20 @@
+import numpy as np
+from fastparquet import quantize
+
+def test_quantize_float32():
+    seed = 2454389
+    rng = np.random.RandomState(seed=seed)
+    data = rng.normal(size=100000).astype(np.float32)
+    buff = quantize.quantize_and_compress_float32(data, 0.1, 0.0, seed=1234)
+    check_data = quantize.dequantize_and_decompress(buff)
+    std = np.std(data - check_data)
+    assert std < 0.05, "RICE float quantization and compression for float 32 is broken!"
+
+def test_quantize_float32():
+    seed = 2454389
+    rng = np.random.RandomState(seed=seed)
+    data = rng.normal(size=100000).astype(np.float64)
+    buff = quantize.quantize_and_compress_float64(data, 0.1, 0.0, seed=1234)
+    check_data = quantize.dequantize_and_decompress(buff)
+    std = np.std(data - check_data)
+    assert std < 0.05, "RICE float quantization and compression for float 64 is broken!"

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -619,10 +619,16 @@ def make_row_group(f, data, schema, compression=None,
                 comp = compression.get(column.name, None)
             else:
                 comp = compression
+
+            if isinstance(quantization_level, dict):
+                quant_level = quantization_level.get(column.name, None)
+            else:
+                quant_level = quantization_level
+
             chunk = write_column(
                 f, data[column.name], column,
                 compression=comp,
-                quantization_level=quantization_level,
+                quantization_level=quant_level,
                 quantization_random_state=quantization_random_state)
             rg.columns.append(chunk)
     rg.total_byte_size = sum([c.meta_data.total_uncompressed_size for c in
@@ -799,10 +805,11 @@ def write(filename, data, row_group_offsets=50000000,
         resolution; in "int96" mode, they are written as 12-byte blocks, with
         the first 8 bytes as ns within the day, the next 4 bytes the julian day.
         'int96' mode is included only for compatibility.
-    quantization_level: int or None
+    quantization_level: int, dict or None
         If not None, then quantization_level floating point values in this many units of the
         median absolute deviation of the column. Only works for the 'simple' file
-        scheme.
+        scheme. To specify a different value per column, use a dictionary keyed on the
+        column names (i.e. `{col1: 10, col2: 5}`).
     quantization_random_seed: int (greater than 0), `np.random.RandomState`, or None
         The seed or RNG for the dithering of the quantized float values. If None, then the
         a `np.random.RandomState` instance is instantiated using its default (non-deterministic)

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -11,6 +11,7 @@ import struct
 import sys
 import thriftpy
 import warnings
+import time
 
 import numba
 
@@ -25,6 +26,7 @@ from .util import (default_open, default_mkdirs, sep_from_open,
                    ParquetException, thrift_copy, index_like, PY2, STR_TYPE,
                    check_column_names, metadata_from_many, created_by)
 from .speedups import array_encode_utf8, pack_byte_array
+from . import quantize
 
 MARKER = b'PAR1'
 NaT = np.timedelta64(None).tobytes()  # require numpy version >= 1.7
@@ -369,11 +371,52 @@ def encode_dict(data, se):
     encode_unsigned_varint(bit_packed_count << 1 | 1, o)  # write run header
     return o.so_far().tostring() + data.values.tostring()
 
+
+# Cache the median absolute deviation of columns here per call to `write`.
+COLUMN_MADS = {}
+
+def encode_lossy_rice(data, se, quantization_level):
+    global COLUMN_MADS
+
+    if data.name not in COLUMN_MADS:
+        # Really good idea from J. Michelson to use every n-th value
+        # to speed up MAD computation.
+        # Using it here to keep just 10k values for MAD computation.
+        if data.shape[0] > 10000:
+            modval = data.shape[0] // 10000
+            vals = data.values[::modval]
+        else:
+            vals = data.values
+
+        # Use median abolsute deviation to estimate scale of distribution,
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', message='All-NaN', category=RuntimeWarning, append=True)
+            scale = (np.nanmedian(np.abs(vals - np.nanmedian(vals))) *
+                     1.4826 /
+                     quantization_level)
+            scale = scale if scale > 0.0 else 1.0
+
+        # Cache it to save time for later row groups.
+        COLUMN_MADS[data.name] = scale
+    else:
+        scale = COLUMN_MADS[data.name]
+    zero_point = np.nanmin(data.values) - scale * (-2147483647 + 10)
+    seed = int(time.time())
+
+    if 'float64' in str(data.values.dtype):
+        return quantize.quantize_and_compress_float64(
+            np.ascontiguousarray(data.values), scale, zero_point, seed)
+    else:
+        return quantize.quantize_and_compress_float32(
+            np.ascontiguousarray(data.values), scale, zero_point, seed)
+
 encode = {
     'PLAIN': encode_plain,
     'RLE': encode_rle,
     'PLAIN_DICTIONARY': encode_dict,
     # 'DELTA_BINARY_PACKED': encode_delta
+    'LOSSY_RICE': encode_lossy_rice,
 }
 
 
@@ -402,7 +445,7 @@ def make_definitions(data, no_nulls):
     return block, out
 
 
-def write_column(f, data, selement, compression=None):
+def write_column(f, data, selement, compression=None, quantization_level=None):
     """
     Write a single column of data to an open Parquet file
 
@@ -414,6 +457,10 @@ def write_column(f, data, selement, compression=None):
         produced by ``find_type``
     compression: str or None
         if not None, must be one of the keys in ``compression.compress``
+    quantization_level: int or None
+        If not None, floating point values are quantized in units of the median
+        absolute deviation divided by `quantization_level`. These integer values are then RICE
+        encoded.
 
     Returns
     -------
@@ -477,10 +524,14 @@ def write_column(f, data, selement, compression=None):
         encoding = "PLAIN_DICTIONARY"
     elif str(data.dtype) in ['int8', 'int16', 'uint8', 'uint16']:
         encoding = "RLE"
+    elif str(data.dtype) in ['float32', 'float64'] and quantization_level is not None:
+        encoding = "LOSSY_RICE"
 
     start = f.tell()
-    bdata = definition_data + repetition_data + encode[encoding](
-            data, selement)
+    encoding_args = [data, selement]
+    if encoding == 'LOSSY_RICE':
+        encoding_args.append(quantization_level)
+    bdata = definition_data + repetition_data + encode[encoding](*encoding_args)
     bdata += 8 * b'\x00'
     try:
         if encoding != 'PLAIN_DICTIONARY' and num_nulls == 0:
@@ -547,7 +598,7 @@ def write_column(f, data, selement, compression=None):
     return chunk
 
 
-def make_row_group(f, data, schema, compression=None):
+def make_row_group(f, data, schema, compression=None, quantization_level=None):
     """ Make a single row group of a Parquet file """
     rows = len(data)
     if rows == 0:
@@ -565,7 +616,7 @@ def make_row_group(f, data, schema, compression=None):
             else:
                 comp = compression
             chunk = write_column(f, data[column.name], column,
-                                 compression=comp)
+                                 compression=comp, quantization_level=quantization_level)
             rg.columns.append(chunk)
     rg.total_byte_size = sum([c.meta_data.total_uncompressed_size for c in
                               rg.columns])
@@ -637,7 +688,7 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
 
 
 def write_simple(fn, data, fmd, row_group_offsets, compression,
-                 open_with, has_nulls, append=False):
+                 open_with, has_nulls, append=False, quantization_level=None):
     """
     Write to one single file (for file_scheme='simple')
     """
@@ -661,7 +712,7 @@ def write_simple(fn, data, fmd, row_group_offsets, compression,
             end = (row_group_offsets[i+1] if i < (len(row_group_offsets) - 1)
                    else None)
             rg = make_row_group(f, data[start:end], fmd.schema,
-                                compression=compression)
+                                compression=compression, quantization_level=quantization_level)
             if rg is not None:
                 fmd.row_groups.append(rg)
 
@@ -674,7 +725,7 @@ def write(filename, data, row_group_offsets=50000000,
           compression=None, file_scheme='simple', open_with=default_open,
           mkdirs=default_mkdirs, has_nulls=None, write_index=None,
           partition_on=[], fixed_text=None, append=False,
-          object_encoding='infer', times='int64'):
+          object_encoding='infer', times='int64', quantization_level=None):
     """ Write Pandas DataFrame to filename as Parquet Format
 
     Parameters
@@ -737,11 +788,19 @@ def write(filename, data, row_group_offsets=50000000,
         resolution; in "int96" mode, they are written as 12-byte blocks, with
         the first 8 bytes as ns within the day, the next 4 bytes the julian day.
         'int96' mode is included only for compatibility.
+    quantization_level: int or None
+        If not None, then quantization_level floating point values in this many units of the
+        median absolute deviation of the column. Only works for the 'simple' file
+        scheme.
 
     Examples
     --------
     >>> fastparquet.write('myfile.parquet', df)  # doctest: +SKIP
     """
+
+    global COLUMN_MADS
+    COLUMN_MADS = {}
+
     sep = sep_from_open(open_with)
     if isinstance(row_group_offsets, int):
         l = len(data)
@@ -759,7 +818,8 @@ def write(filename, data, row_group_offsets=50000000,
 
     if file_scheme == 'simple':
         write_simple(filename, data, fmd, row_group_offsets,
-                     compression, open_with, has_nulls, append)
+                     compression, open_with, has_nulls, append,
+                     quantization_level)
     elif file_scheme == 'hive':
         if append:
             pf = api.ParquetFile(filename, open_with=open_with)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,11 @@ from Cython.Build import cythonize
 
 cython_modules = [Extension('fastparquet.speedups',
                             ['fastparquet/speedups.pyx'],
-                            include_dirs=[np.get_include()])]
+                            include_dirs=[np.get_include()]),
+                  Extension('fastparquet.quantize._quantize',
+                            ['fastparquet/quantize/_quantize.pyx', 'fastparquet/quantize/rice.c'],
+                            include_dirs=[np.get_include()]),
+                            ]
 
 ext_modules = cythonize(cython_modules)
 


### PR DESCRIPTION
This PR adds lossy compression of float columns using a float quantization technique from this [paper](http://iopscience.iop.org/article/10.1086/656249/pdf). 

The motivation here is that typically that actual amount of information in our data is much less than the precision with which we store it. This is especially true for algorithms in machine learning.

To Do
------
- [x] add a `seed` argument to write instead of using the current time! (Whoops! :) I forgot that I hacked this in while doing dev, but this is an easy fix.)
- [x] more tests
- [x] fix overlapping tests
- [x] add different levels per column
- [x] move the LOSSY_RICE key to some large value in the parquet thrift file
- [ ] implement for HIVE too
- [ ] deal with RNG portability (Maybe roll our own internally? It doesn't actually have to be very good to be effective. The fpack routines roll their own RNG internally for the same reason. Numpy probably solves this for us TBH, but it is something to think hard about.)

Description
-----------
1. Use some robust estimate of a standard deviation, like a median absolute deviation, to determine the typical variation of values in a given column. 
2. Pick a **bin width**, namely the size of the bins with which you want to quantize your floating point values. Typical choices in astronomy are some fraction of the scale from 1) above. In this implementation, I use `bin_width = MAD / quantization_level`. Typical values for the `quantization_level` are 4-10.
3. Convert all floating point values to ints using (roughly) `int_value = NINT((float_value - zero_point)/scale)`. This is not actually what is done due to dithering that is needed to debias the result. `NINT` is the nearest integer function. See below.
4. Use [RICE coding](https://en.wikipedia.org/wiki/Golomb_coding#Rice_coding) to exactly compress the resulting integers to a smaller number of bytes. Note that the RICE coding here is done on the differences between adjacent values, not the raw values.

Implementation Details
-----------------------
* **Dithering**: Just truncating the floating point values to ints would result in biased statistics when the values are decompressed. Thus one uses a random dithering technique called **subtractive dithering** to ensure that resulting decompressed values will give statistically unbiased results for things like medians or modes.
* **Special Values**: In many cases, people store one-hot-encoded values (i.e., columns with just 0's and 1's) as floats for use with tools like scikit-learn where a singly typed numpy array is expected. Thus it makes sense to encode these values exactly. In this technique, you do this by assigning special int32 values to these values (and also to NaN). Then when decompressing, you find these special int values and put back the proper floating point values. This PR encodes exactly the special values `NaN`, `0.0` and `1.0`.
* **RICE coding**: I have used the RICE coding library from the [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/fitsio.html) package. I have additionally leveraged previous python wrappers developed [here](https://github.com/tclarke/ricecomp-cfitsio-python) in this implementation. All original licenses were kept and are BSD-3 clause compatible.
* **Cython**: Everything here is in C and cython resulting in decent performance.
* **Limitations**: Only `int32` is supported right now for the compressed format. It should be possible to use RICE coded int64 values too, but this is not implemented here. I also do not do any checking that the truncation of the floating point values would result in stuff moving out of the dynamic range of an `int32`. IMO, the user should be responsible for making sure this does not happen.

Performance
-------------
On a ~6.7 GB csv which is ~40% sparse (i.e. one-hot-encoded zeros), I get compression ratios of ~21x. After the data is read into memory, it takes ~30 seconds to write the data to disk and another ~12 seconds to read the data back out from the file. These tests were done with `quantization_level=10`. Note that setting this value even smaller (i.e., 4 which gives more compression) is very common in astronomy. Relative to binary `float32` one typically can get ~5x compression ratios.

Use Case
----------
I expect this technique to be useful when especially large datasets need to be moved over network connections on a regular basis or, say, when you have storage constraints. See some further benchmarking in a comment below.

Extensions
-----------
One extension to this PR is to use RICE coding on int32 and int64 columns by default. I have tested this out in other versions of this code on `int32` values (and also smaller ints). You get additional compression, but at a performance decrease in I/O speeds. Thus including an option to do this might be useful and is an easy thing to add to either this PR or another and would leverage a lot of the same underlying code.

Tests
-----
I have added basic tests, but more can and should be done.