### PR TITLE
Allow encoding of object columns as bool/int

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -379,8 +379,8 @@ class ParquetFile(object):
                           if f.num_children in [None, 0] else np.dtype("O"))
                  for f in self.schema.root.children.values()}
         for col, dt in dtype.copy().items():
-            if dt.kind == 'i':
-                # int columns that may have nulls become float columns
+            if dt.kind in ['i', 'b']:
+                # int/bool columns that may have nulls become float columns
                 num_nulls = 0
                 for rg in self.row_groups:
                     chunks = [c for c in rg.columns


### PR DESCRIPTION
The only way to store int-with-None and bool-with-None in pandas
is in an object column. This adds object_encoding types 'bool' and
'int' (which can be auto-inferred) to store such columns.

Caveat: bool columns containing nulls get cast to float on load,
rather than creating expensive python objects. This is not then a
true round-trip, and this decision is open to discussion.

TODO: update documentation concerning object_encoding.