### PR TITLE
Use pandas Index machinery to infer index type

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -87,9 +87,9 @@ class ParquetFile(object):
         f.seek(-(head_size+8), 2)
         try:
             fmd = read_thrift(f, parquet_thrift.FileMetaData)
-        except thriftpy.transport.TTransportException:
+        except Exception:
             raise ParquetException('Metadata parse failed: %s' %
-                                         self.fn)
+                                   self.fn)
         self.head_size = head_size
         self.fmd = fmd
         self._set_attrs()

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pandas.core.index import _ensure_index, CategoricalIndex
+from pandas.core.index import _ensure_index, CategoricalIndex, Index
 from pandas.core.internals import BlockManager, _block_shape
 from pandas.core.generic import NDFrame
 from pandas.core.frame import DataFrame
@@ -77,8 +77,8 @@ def empty(types, size, cats=None, cols=None, index_type=None, index_name=None):
             index._data._codes = vals
             views[index_name] = vals
         else:
-            index = np.empty(size, dtype=index_type)
-            views[index_name] = index
+            index = Index(np.empty(size, dtype=index_type))
+            views[index_name] = index.values
 
         axes = [df._data.axes[0], index]
     else:

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -120,6 +120,27 @@ def test_attributes(tempdir):
         assert pf.dtypes[col] == df.dtypes[col]
 
 
+def test_cast_index(tempdir):
+    df = pd.DataFrame({'i8': np.array([1, 2, 3, 4], dtype='uint8'),
+                       'i16': np.array([1, 2, 3, 4], dtype='int16'),
+                       'i32': np.array([1, 2, 3, 4], dtype='int32'),
+                       'i62': np.array([1, 2, 3, 4], dtype='int64'),
+                       'f16': np.array([1, 2, 3, 4], dtype='float16'),
+                       'f32': np.array([1, 2, 3, 4], dtype='float32'),
+                       'f64': np.array([1, 2, 3, 4], dtype='float64'),
+                       })
+    fn = os.path.join(tempdir, 'foo.parquet')
+    write(fn, df)
+    pf = ParquetFile(fn)
+    for col in list(df):
+        d = pf.to_pandas(index=col)
+        if d.index.dtype.kind == 'i':
+            assert d.index.dtype == 'int64'
+        else:
+            assert d.index.dtype == 'float64'
+        assert (d.index == df[col]).all()
+
+
 def test_zero_child_leaf(tempdir):
     df = pd.DataFrame({'x': [1, 2, 3]})
 


### PR DESCRIPTION
Was silently creating new array for index with incorrect type for
int32, float 32

Fixes https://github.com/dask/dask/issues/2240

Needs tests.