### PR TITLE
ENH allow object conversions to floating point

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -491,6 +491,9 @@ def test_auto_null(tempdir):
                        'ff': [True, False, None, True]})
     df['e'] = df['d'].astype('category')
     df['bb'] = df['b'].astype('object')
+    df['aaa'] = df['a'].astype('object')
+    object_cols = ['d', 'ff', 'bb', 'aaa']
+    test_cols = list(set(df) - set(object_cols)) + ['d']
     fn = os.path.join(tmp, "test.parq")
 
     with pytest.raises((TypeError, AttributeError)):
@@ -503,9 +506,10 @@ def test_auto_null(tempdir):
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     df2 = pf.to_pandas(categories=['e'])
 
-    cols = list(set(df) - {'ff'})
-    tm.assert_frame_equal(df[cols], df2[cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
+    tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
     # not giving any value same as has_nulls=True
     write(fn, df)
@@ -514,33 +518,38 @@ def test_auto_null(tempdir):
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     df2 = pf.to_pandas(categories=['e'])
 
-    cols = list(set(df) - {'ff'})
-    tm.assert_frame_equal(df[cols], df2[cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
+    tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
     # 'infer' is new recommended auto-null
     write(fn, df, has_nulls='infer')
     pf = ParquetFile(fn)
     for col in pf._schema[1:]:
-        if col.name in ['d', 'ff']:
+        if col.name in object_cols:
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
         else:
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
     df2 = pf.to_pandas()
-    tm.assert_frame_equal(df[cols], df2[cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
+    tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
     # nut legacy None still works
     write(fn, df, has_nulls=None)
     pf = ParquetFile(fn)
     for col in pf._schema[1:]:
-        if col.name in ['d', 'ff']:
+        if col.name in object_cols:
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
         else:
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
     df2 = pf.to_pandas()
-    tm.assert_frame_equal(df[cols], df2[cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
+    tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
 
 @pytest.mark.parametrize('n', (10, 127, 2**8 + 1, 2**16 + 1))

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -490,6 +490,7 @@ def test_auto_null(tempdir):
                        'f': [True, False, True, True],
                        'ff': [True, False, None, True]})
     df['e'] = df['d'].astype('category')
+    df['bb'] = df['b'].astype('object')
     fn = os.path.join(tmp, "test.parq")
 
     with pytest.raises((TypeError, AttributeError)):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -66,7 +66,7 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
     fixed_text: int or None
         For str and bytes, the fixed-string length to use. If None, object
         column will remain variable length.
-    object_encoding: None or bytes|utf8\json|bson|bool|int
+    object_encoding: None or infer|bytes|utf8|json|bson|bool|int|float
         How to encode object type into bytes. If None, bytes is assumed;
         if 'infer', type is guessed from 10 first non-null values.
     times: 'int64'|'int96'
@@ -110,9 +110,12 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
         elif object_encoding == 'int':
             type, converted_type, width = (parquet_thrift.Type.INT64, None,
                                            None)
+        elif object_encoding == 'float':
+            type, converted_type, width = (parquet_thrift.Type.DOUBLE, None,
+                                           None)
         else:
             raise ValueError('Object encoding (%s) not one of '
-                             'infer|utf8|bytes|json|bson|bool|int' %
+                             'infer|utf8|bytes|json|bson|bool|int|float' %
                              object_encoding)
         if fixed_text:
             width = fixed_text
@@ -204,6 +207,8 @@ def infer_object_encoding(data):
         return 'bool'
     if all(isinstance(i, int) for i in head):
         return 'int'
+    if all(isinstance(i, float) for i in head):
+        return 'float'
     else:
         raise ValueError("Can't infer object conversion type: %s" % head)
 
@@ -752,8 +757,8 @@ def write(filename, data, row_group_offsets=50000000,
     object_encoding: str or {col: type}
         For object columns, this gives the data type, so that the values can
         be encoded to bytes. Possible values are bytes|utf8|json|bson|bool|int,
-        where bytes is assumed if not specified (i.e., no conversion). The 
-        special value 'infer' will cause the type to be guessed from the first 
+        where bytes is assumed if not specified (i.e., no conversion). The
+        special value 'infer' will cause the type to be guessed from the first
         ten non-null values.
     times: 'int64' (default), or 'int96':
         In "int64" mode, datetimes are written as 8-byte integers, us


### PR DESCRIPTION
I am not sure if this was supposed to not be there for some reason. Without these changes, this fails

```python
d = pd.DataFrame({'x': np.random.normal(size=100)})
d['x'] = d['x'].astype(object)
fastparquet.write('test.parq', d)
```