### PR TITLE
Do not attempt to recurse into schema elements with zero children

### DIFF
--- a/fastparquet/schema.py
+++ b/fastparquet/schema.py
@@ -22,7 +22,7 @@ def schema_tree(schema, i=0):
         i += 1
         s = schema[i]
         root.children[s.name] = s
-        if s.num_children is not None:
+        if s.num_children not in [None, 0]:
             i = schema_tree(schema, i)
     if root.num_children:
         return i


### PR DESCRIPTION
Before only skipped if num_children was None, but now also skip
if 0.

Fixes problem 2 in https://github.com/pandas-dev/pandas/pull/15838