### PR TITLE
Implement writing pandas metadata and auto-setting cats/index

### DIFF
--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -640,17 +640,14 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
     root = parquet_thrift.SchemaElement(name='schema',
                                         num_children=0)
 
-    cats = parquet_thrift.KeyValue()
-    cats.key = 'fastparquet.cats'
     meta = parquet_thrift.KeyValue()
     meta.key = 'pandas'
-    catstruct = {}
     fmd = parquet_thrift.FileMetaData(num_rows=len(data),
                                       schema=[root],
                                       version=1,
                                       created_by=created_by,
                                       row_groups=[],
-                                      key_value_metadata=[cats, meta])
+                                      key_value_metadata=[meta])
 
     object_encoding = object_encoding or {}
     for column in data.columns:
@@ -665,7 +662,6 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
             se, type = find_type(data[column].cat.categories,
                                  fixed_text=fixed, object_encoding=oencoding)
             se.name = column
-            catstruct[column] = len(data[column].cat.categories)
         else:
             se, type = find_type(data[column], fixed_text=fixed,
                                  object_encoding=oencoding, times=times)
@@ -679,7 +675,6 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
         fmd.schema.append(se)
         root.num_children += 1
     meta.value = json.dumps(pandas_metadata)
-    cats.value = json.dumps(catstruct)
     return fmd
 
 


### PR DESCRIPTION
Only copes with single index, not compound (as was the case in fastparquet
so far).

See the [spec](https://github.com/pandas-dev/pandas/blob/master/doc/source/developer.rst)