### PR TITLE
Allow partition_on; fix category nuls

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -803,3 +803,14 @@ def test_cats_in_part_files(tempdir):
     out = pd.concat([ParquetFile(f).to_pandas() for f in files],
                     ignore_index=True)
     pd.util.testing.assert_frame_equal(df, out)
+
+
+def test_cats_and_nulls(tempdir):
+    df = pd.DataFrame({'x': pd.Categorical([1, 2, 1])})
+    fn = os.path.join(tempdir, 'temp.parq')
+    write(fn, df)
+    pf = ParquetFile(fn)
+    assert not pf.schema.is_required('x')
+    out = pf.to_pandas()
+    assert out.dtypes['x'] == 'category'
+    assert out.x.tolist() == [1, 2, 1]

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -246,6 +246,7 @@ def get_column_metadata(column, name):
             'num_categories': len(column.cat.categories),
             'ordered': column.cat.ordered,
         }
+        dtype = column.cat.codes.dtype
     elif hasattr(dtype, 'tz'):
         extra_metadata = {'timezone': str(dtype.tz)}
     else:


### PR DESCRIPTION
- Don't edit the FMD from within partitioning - pass back row_groups, so that dask can gather these and put into one metadata.
- Bug in checking for nulls on write with categorical column (turns out that dtype.kind of a categorical column is also "O")