### PR TITLE
Fix ImportWarning on Python 3.6+

### DIFF
--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -2,6 +2,8 @@
 Native accelerators for Parquet encoding and decoding.
 """
 
+from __future__ import absolute_import
+
 cdef extern from "string.h":
     void *memcpy(void *dest, const void *src, size_t n)
 


### PR DESCRIPTION
See https://github.com/cython/cython/issues/1720
(other ImportWarnings come from pandas)