### PR TITLE
Allow pip install without NumPy or Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,29 @@
 """setup.py - build script for parquet-python."""
 
 import os
+import sys
 try:
     from setuptools import setup, Extension
 except ImportError:
     from distutils.core import setup, Extension
 
-import numpy as np
-
-from Cython.Build import cythonize
-
-
-cython_modules = [Extension('fastparquet.speedups',
-                            ['fastparquet/speedups.pyx'],
-                            include_dirs=[np.get_include()])]
-
-ext_modules = cythonize(cython_modules)
-
+allowed = ('--help-commands', '--version', 'egg_info', 'clean')
+if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1] in allowed):
+    # NumPy and cython are not required for these actions. They must succeed
+    # so pip can install fastparquet when these requirements are not available.
+    extra = {}
+else:
+    import numpy as np
+    from Cython.Build import cythonize
+    cython_modules = [Extension('fastparquet.speedups',
+                                ['fastparquet/speedups.pyx'],
+                                include_dirs=[np.get_include()])]
+    extra = {'ext_modules': cythonize(cython_modules)}
 
 setup(
     name='fastparquet',
     version='0.1.0',
     description='Python support for Parquet file format',
-    ext_modules=ext_modules,
     author='Martin Durant',
     author_email='mdurant@continuum.io',
     url='https://github.com/martindurant/fastparquet/',
@@ -46,4 +47,5 @@ setup(
                       else ''),
     package_data={'fastparquet': ['*.thrift']},
     include_package_data=True,
+    **extra
 )


### PR DESCRIPTION
Allow fastparquet to be installed when NumPy and Cython are not already
installed. pip attempts to run `python setup.py egg_info` to detemine the
install requirements.  Allow this command and other non-build related commands
to be run without importing numpy or cython.

closes #170