### PR TITLE
remove redundant SNAPPY from supported compressions list

### DIFF
--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -62,7 +62,7 @@ decompressions = {k.upper(): v for k, v in decompressions.items()}
 
 rev_map = {getattr(parquet_thrift.CompressionCodec, key): key for key in
            dir(parquet_thrift.CompressionCodec) if key in
-           ['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'SNAPPY', 'LZO', 'BROTLI']}
+           ['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI']}
 
 
 def compress_data(data, algorithm='gzip'):


### PR DESCRIPTION
The list of upper-case potentially supported compressions contained `SNAPPY` twice. I simply removed it.
See - [https://github.com/dask/fastparquet/blob/master/fastparquet/compression.py#L65](https://github.com/dask/fastparquet/blob/master/fastparquet/compression.py#L65)