### PR TITLE
Reverted fixed strings regression, allowed to avoid stats on write

### DIFF
--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -99,6 +99,10 @@ def time_text():
                 with measure('%s: write, fixed: %s' % (t, fixed), result):
                     write(fn, df, has_nulls=False, write_index=False,
                           fixed_text={col: fixed}, object_encoding=t)
+                with measure('%s: write, fixed: %s, nostat' % (t, fixed), result):
+                    write(fn, df, has_nulls=False, write_index=False,
+                          fixed_text={col: fixed}, object_encoding=t,
+                          stats=False)
 
                 pf = ParquetFile(fn)
                 pf.to_pandas()  # warm-up

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -8,7 +8,7 @@ import array
 import numba
 import numpy as np
 
-from .speedups import decode
+from .speedups import decode, array_decode
 from .thrift_structures import parquet_thrift
 from .util import byte_buffer
 
@@ -38,7 +38,7 @@ def read_plain(raw_bytes, type_, count, width=0, se=None):
         out = np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
         if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
                                  parquet_thrift.ConvertedType.JSON]:
-            return np.char.decode(out, 'utf8')
+            return array_decode(out)
         else:
             return out
     if type_ == parquet_thrift.Type.BOOLEAN:

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -27,6 +27,7 @@ cdef extern from "Python.h":
     int PyUnicode_Check(object text)
     int PyBytes_AsStringAndSize(bytes obj, char **buffer, Py_ssize_t *length)
     char* PyUnicode_AsUTF8AndSize(unicode unicode, Py_ssize_t *size)
+    unicode PyUnicode_DecodeUTF8(char *s, Py_ssize_t size, char *errors)
 
 
 @cython.wraparound(False)
@@ -121,4 +122,31 @@ def decode(bytes buf, int n_items, bint utf8=1):
             out[i] = PyBytes_FromStringAndSize(data, l)
         data += l
 
+    return out
+
+
+def array_encode(np.ndarray[object, ndim=1] data):
+    cdef:
+        Py_ssize_t i, n
+
+    n = len(data)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        out[i] = PyUnicode_AsUTF8String(data[i])
+    return out
+
+
+def array_decode(np.ndarray data):
+    cdef:
+        Py_ssize_t i, n
+
+    n = len(data)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        val = data[i]
+        out[i] = PyUnicode_DecodeUTF8(
+            PyBytes_AS_STRING(val),
+            PyBytes_GET_SIZE(val),
+            NULL,   # errors
+            )
     return out


### PR DESCRIPTION
Strings en/decoding speedups inspired by https://github.com/alimanfoo/numcodecs/blob/e94a182e28d47b0e3a8aecd902b9e82f48b720b2/numcodecs/vlen.pyx (see [discussion](https://github.com/alimanfoo/numcodecs/pull/56))

Benchmarks (time taken, smaller is better):
branch
utf8: read, fixed: 6 162.019
utf8: read, fixed: None 122.684
utf8: write, fixed: 6 169.497
utf8: write, fixed: 6, nostat 111.139
utf8: write, fixed: None 83.332
utf8: write, fixed: None, nostat 29.057

master:
utf8: read, fixed: 6 174.109
utf8: read, fixed: None 182.614
utf8: write, fixed: 6 148.194
utf8: write, fixed: None 154.619

"nostat" is the new option not to bother creating column metadata statistics.

The most common codepath is UTF8 read, not fixed: 180->120ms, good gain.

cc @alimanfoo