### PR TITLE
Speedup speedup

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -541,12 +541,12 @@ def filter_out_stats(rg, filters, schema):
                 s = column.meta_data.statistics
                 if s.max is not None:
                     b = ensure_bytes(s.max)
-                    vmax = encoding.read_plain(b, column.meta_data.type, 1)
+                    vmax = encoding.read_plain(b, column.meta_data.type, 1, se)
                     if se.converted_type is not None:
                         vmax = converted_types.convert(vmax, se)
                 if s.min is not None:
                     b = ensure_bytes(s.min)
-                    vmin = encoding.read_plain(b, column.meta_data.type, 1)
+                    vmin = encoding.read_plain(b, column.meta_data.type, 1, se)
                     if se.converted_type is not None:
                         vmin = converted_types.convert(vmin, se)
                 out = filter_val(op, val, vmin, vmax)

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -99,6 +99,10 @@ def time_text():
                 with measure('%s: write, fixed: %s' % (t, fixed), result):
                     write(fn, df, has_nulls=False, write_index=False,
                           fixed_text={col: fixed}, object_encoding=t)
+                with measure('%s: write, fixed: %s, nostat' % (t, fixed), result):
+                    write(fn, df, has_nulls=False, write_index=False,
+                          fixed_text={col: fixed}, object_encoding=t,
+                          stats=False)
 
                 pf = ParquetFile(fn)
                 pf.to_pandas()  # warm-up

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -92,7 +92,6 @@ def time_text():
                 df = d[[col]]
                 if isinstance(df.iloc[0, 0], bytes):
                     t = "bytes"
-                    continue
                 else:
                     t = 'utf8'
                 write(fn, df)

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -92,6 +92,7 @@ def time_text():
                 df = d[[col]]
                 if isinstance(df.iloc[0, 0], bytes):
                     t = "bytes"
+                    continue
                 else:
                     t = 'utf8'
                 write(fn, df)

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -97,8 +97,6 @@ def convert(data, se, timestamp96=True):
     if ctype is None:
         return data
     if ctype == parquet_thrift.ConvertedType.UTF8:
-        if isinstance(data, list) or data.dtype != "O":
-            data = np.asarray(data, dtype="O")
         return data
     if ctype == parquet_thrift.ConvertedType.DECIMAL:
         scale_factor = 10**-se.scale
@@ -154,7 +152,7 @@ def convert(data, se, timestamp96=True):
             out = np.empty(len(data), dtype="O")
         else:
             out = data
-        out[:] = [json.loads(d.decode('utf8')) for d in data]
+        out[:] = [json.loads(d) for d in data]
         return out
     elif ctype == parquet_thrift.ConvertedType.BSON:
         if isinstance(data, list) or data.dtype != "O":

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -20,7 +20,6 @@ import binascii
 
 from .thrift_structures import parquet_thrift
 from .util import PY2
-from .speedups import array_decode_utf8
 
 logger = logging.getLogger('parquet')  # pylint: disable=invalid-name
 
@@ -100,7 +99,7 @@ def convert(data, se, timestamp96=True):
     if ctype == parquet_thrift.ConvertedType.UTF8:
         if isinstance(data, list) or data.dtype != "O":
             data = np.asarray(data, dtype="O")
-        return array_decode_utf8(data)
+        return data
     if ctype == parquet_thrift.ConvertedType.DECIMAL:
         scale_factor = 10**-se.scale
         if data.dtype.kind in ['i', 'f']:

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -14,7 +14,7 @@ from . import encoding
 from .compression import decompress_data
 from .converted_types import convert, typemap
 from .schema import _is_list_like, _is_map_like
-from .speedups import decodeutf8, decodebytes
+from .speedups import decode
 from .thrift_structures import parquet_thrift, read_thrift
 from .util import val_to_num, byte_buffer, ex_from_sep
 
@@ -160,11 +160,13 @@ def read_dictionary_page(file_obj, schema_helper, page_header, column_metadata):
     if column_metadata.type == parquet_thrift.Type.BYTE_ARRAY:
         if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
                                  parquet_thrift.ConvertedType.JSON]:
-            values = decodeutf8(raw_bytes,
-                                page_header.dictionary_page_header.num_values)
+            values = decode(raw_bytes,
+                            page_header.dictionary_page_header.num_values,
+                            utf8=True)
         else:
-            values = decodebytes(raw_bytes,
-                                 page_header.dictionary_page_header.num_values)
+            values = decode(raw_bytes,
+                            page_header.dictionary_page_header.num_values,
+                            utf8=False)
     else:
         width = se.type_length
         values = encoding.read_plain(

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -8,7 +8,7 @@ import array
 import numba
 import numpy as np
 
-from .speedups import decodebytes, decodeutf8
+from .speedups import decode
 from .thrift_structures import parquet_thrift
 from .util import byte_buffer
 
@@ -41,9 +41,9 @@ def read_plain(raw_bytes, type_, count, width=0, se=None):
     try:
         if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
                                  parquet_thrift.ConvertedType.JSON]:
-            return decodeutf8(raw_bytes, count)
+            return decode(raw_bytes, count, utf8=True)
         else:
-            return decodebytes(raw_bytes, count)
+            return decode(raw_bytes, count, utf8=False)
     except RuntimeError:
         if count == 1:
             if se.converted_type in [parquet_thrift.ConvertedType.UTF8,

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -35,7 +35,12 @@ def read_plain(raw_bytes, type_, count, width=0, se=None):
         if count == 1:
             width = len(raw_bytes)
         dtype = np.dtype('S%i' % width)
-        return np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
+        out = np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
+        if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
+                                 parquet_thrift.ConvertedType.JSON]:
+            return np.char.decode(out, 'utf8')
+        else:
+            return out
     if type_ == parquet_thrift.Type.BOOLEAN:
         return read_plain_boolean(raw_bytes, count)
     try:

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -8,7 +8,7 @@ import array
 import numba
 import numpy as np
 
-from .speedups import unpack_byte_array
+from .speedups import decodebytes, decodeutf8
 from .thrift_structures import parquet_thrift
 from .util import byte_buffer
 
@@ -27,7 +27,7 @@ DECODE_TYPEMAP = {
 }
 
 
-def read_plain(raw_bytes, type_, count, width=0):
+def read_plain(raw_bytes, type_, count, width=0, se=None):
     if type_ in DECODE_TYPEMAP:
         dtype = DECODE_TYPEMAP[type_]
         return np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
@@ -38,13 +38,19 @@ def read_plain(raw_bytes, type_, count, width=0):
         return np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
     if type_ == parquet_thrift.Type.BOOLEAN:
         return read_plain_boolean(raw_bytes, count)
-    # variable byte arrays (rare)
     try:
-        return np.array(unpack_byte_array(raw_bytes, count), dtype='O')
+        if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
+                                 parquet_thrift.ConvertedType.JSON]:
+            return decodeutf8(raw_bytes, count)
+        else:
+            return decodebytes(raw_bytes, count)
     except RuntimeError:
         if count == 1:
-            # e.g., for statistics
-            return np.array([raw_bytes], dtype='O')
+            if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
+                                     parquet_thrift.ConvertedType.JSON]:
+                return np.array([raw_bytes.decode('utf8')], dtype='O')
+            else:
+                return np.array([raw_bytes], dtype='O')
         else:
             raise
 

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -8,7 +8,7 @@ import array
 import numba
 import numpy as np
 
-from .speedups import decode
+from .speedups import decode, array_decode
 from .thrift_structures import parquet_thrift
 from .util import byte_buffer
 
@@ -38,7 +38,7 @@ def read_plain(raw_bytes, type_, count, width=0, se=None):
         out = np.frombuffer(byte_buffer(raw_bytes), dtype=dtype, count=count)
         if se.converted_type in [parquet_thrift.ConvertedType.UTF8,
                                  parquet_thrift.ConvertedType.JSON]:
-            return np.char.decode(out, 'utf8')
+            return array_decode(out)
         else:
             return out
     if type_ == parquet_thrift.Type.BOOLEAN:

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -27,6 +27,7 @@ cdef extern from "Python.h":
     int PyUnicode_Check(object text)
     int PyBytes_AsStringAndSize(bytes obj, char **buffer, Py_ssize_t *length)
     char* PyUnicode_AsUTF8AndSize(unicode unicode, Py_ssize_t *size)
+    unicode PyUnicode_DecodeUTF8(char *s, Py_ssize_t size, char *errors)
 
 
 @cython.wraparound(False)
@@ -121,4 +122,31 @@ def decode(bytes buf, int n_items, bint utf8=1):
             out[i] = PyBytes_FromStringAndSize(data, l)
         data += l
 
+    return out
+
+
+def array_encode(np.ndarray[object, ndim=1] data):
+    cdef:
+        Py_ssize_t i, n
+
+    n = len(data)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        out[i] = PyUnicode_AsUTF8String(data[i])
+    return out
+
+
+def array_decode(np.ndarray data):
+    cdef:
+        Py_ssize_t i, n
+
+    n = len(data)
+    out = np.empty(n, dtype=object)
+    for i in range(n):
+        val = data[i]
+        out[i] = PyUnicode_DecodeUTF8(
+            PyBytes_AS_STRING(val),
+            PyBytes_GET_SIZE(val),
+            NULL,   # errors
+            )
     return out

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -15,6 +15,7 @@ from cpython cimport (array, PyBytes_GET_SIZE, PyBytes_AS_STRING, PyBytes_Check,
 from cpython.buffer cimport (PyBUF_ANY_CONTIGUOUS, PyObject_GetBuffer,
                              PyBuffer_Release)
 from libc.string cimport memcpy
+from libc.stdlib cimport malloc, free
 
 PY2 = sys.version_info[0] == 2
 _obj_dtype = np.dtype('object')
@@ -24,18 +25,20 @@ cdef extern from "Python.h":
     char* PyByteArray_AS_STRING(object string)
     object PyUnicode_FromStringAndSize(const char *u, Py_ssize_t size)
     int PyUnicode_Check(object text)
+    int PyBytes_AsStringAndSize(bytes obj, char **buffer, Py_ssize_t *length)
+    char* PyUnicode_AsUTF8AndSize(unicode unicode, Py_ssize_t *size)
 
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def encodeutf8(buf):
+def encode(buf, bint utf8=1):
     cdef:
         Py_ssize_t i, l, n_items, data_length, total_length
         object[:] input_values
-        object[:] encoded_values
+        char** encoded_values
         int[:] encoded_lengths
         char* encv
-        bytes b
+        char* b
         bytearray out
         char* data
         object u
@@ -47,18 +50,20 @@ def encodeutf8(buf):
     n_items = input_values.shape[0]
 
     # setup intermediates
-    encoded_values = np.empty(n_items, dtype=object)
+    encoded_values = <char **>malloc(n_items * sizeof(char *))
     encoded_lengths = np.empty(n_items, dtype=np.intc)
 
     # first iteration to convert to bytes
     data_length = 0
     for i in range(n_items):
         u = input_values[i]
-        if not PyUnicode_Check(u):
-            raise TypeError('expected unicode string, found %r' % u)
-        b = PyUnicode_AsUTF8String(u)
-        l = PyBytes_GET_SIZE(b)
-        encoded_values[i] = b
+        if utf8:
+            if not PyUnicode_Check(u):
+                raise TypeError('expected unicode string, found %r' % u)
+            encoded_values[i] = PyUnicode_AsUTF8AndSize(u, &l)
+        else:
+            PyBytes_AsStringAndSize(u, &encv, &l)
+            encoded_values[i] = encv
         data_length += l + 4  # 4 bytes to store item length
         encoded_lengths[i] = l
 
@@ -77,41 +82,31 @@ def encodeutf8(buf):
         data[2] = (l >> 16) & 0xff
         data[3] = (l >> 24) & 0xff
         data += 4
-        encv = PyBytes_AS_STRING(encoded_values[i])
+        encv = encoded_values[i]
         memcpy(data, encv, l)
         data += l
 
+    free(encoded_values)
     return bytes(out)
-
-
-def encodebytes():
-    pass
 
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def decodeutf8(buf, int n_items):
+def decode(bytes buf, int n_items, bint utf8=1):
     cdef:
-        Buffer input_buffer
         char* data
         char* data_end
-        Py_ssize_t i, l, data_length, input_length
+        Py_ssize_t i, l, input_length
 
-    # accept any buffer
-    input_buffer = Buffer(buf, PyBUF_ANY_CONTIGUOUS)
-    input_length = input_buffer.nbytes
-
+    input_length = len(buf)
 
     # obtain input data pointer
-    data = input_buffer.ptr
+    data = buf
     data_end = data + input_length
 
     # setup output
     out = np.empty(n_items, dtype=object)
 
-    # iterate and decode - N.B., do not try to cast `out` as object[:]
-    # as this causes segfaults, possibly similar to
-    # https://github.com/cython/cython/issues/1608
     for i in range(n_items):
         if data + 4 > data_end:
             raise ValueError('corrupt buffer, data seem truncated')
@@ -120,52 +115,10 @@ def decodeutf8(buf, int n_items):
         data += 4
         if data + l > data_end:
             raise ValueError('corrupt buffer, data seem truncated')
-        out[i] = PyUnicode_FromStringAndSize(data, l)
+        if utf8:
+            out[i] = PyUnicode_FromStringAndSize(data, l)
+        else:
+            out[i] = PyBytes_FromStringAndSize(data, l)
         data += l
 
     return out
-
-
-def decodebytes():
-    pass
-
-
-cdef class Buffer:
-    """Compatibility class to work around fact that array.array does not support
-    new-style buffer interface in PY2."""
-    cdef:
-        char *ptr
-        Py_buffer buffer
-        size_t nbytes
-        size_t itemsize
-        array.array arr
-        bint new_buffer
-        bint released
-
-    def __cinit__(self, obj, flags):
-        self.released = False
-        if hasattr(obj, 'dtype'):
-            if obj.dtype.kind in 'Mm':
-                obj = obj.view('u8')
-            elif obj.dtype.kind == 'O':
-                raise ValueError('cannot obtain buffer from object array')
-        if PY2 and isinstance(obj, array.array):
-            self.new_buffer = False
-            self.arr = obj
-            self.ptr = <char *> self.arr.data.as_voidptr
-            self.itemsize = self.arr.itemsize
-            self.nbytes = self.arr.buffer_info()[1] * self.itemsize
-        else:
-            self.new_buffer = True
-            PyObject_GetBuffer(obj, &(self.buffer), flags)
-            self.ptr = <char *> self.buffer.buf
-            self.itemsize = self.buffer.itemsize
-            self.nbytes = self.buffer.len
-
-    cpdef release(self):
-        if self.new_buffer and not self.released:
-            PyBuffer_Release(&(self.buffer))
-            self.released = True
-
-    def __dealloc__(self):
-        self.release()

--- a/fastparquet/speedups.pyx
+++ b/fastparquet/speedups.pyx
@@ -4,164 +4,168 @@ Native accelerators for Parquet encoding and decoding.
 
 from __future__ import absolute_import
 
-cdef extern from "string.h":
-    void *memcpy(void *dest, const void *src, size_t n)
-
-from cpython cimport (PyUnicode_AsUTF8String, PyUnicode_DecodeUTF8,
-                      PyBytes_CheckExact, PyBytes_FromStringAndSize,
-                      PyBytes_GET_SIZE, PyBytes_AS_STRING)
-
+import array
 import numpy as np
 cimport numpy as np
+import cython
+cimport cython
+import sys
+from cpython cimport (array, PyBytes_GET_SIZE, PyBytes_AS_STRING, PyBytes_Check,
+                      PyBytes_FromStringAndSize, PyUnicode_AsUTF8String)
+from cpython.buffer cimport (PyBUF_ANY_CONTIGUOUS, PyObject_GetBuffer,
+                             PyBuffer_Release)
+from libc.string cimport memcpy
 
-
+PY2 = sys.version_info[0] == 2
 _obj_dtype = np.dtype('object')
 
-
-def _to_array(obj):
-    """
-    Convert *obj* (a ndarray-compatible object, e.g. pandas Series)
-    to a true ndarray.
-    """
-    if not isinstance(obj, np.ndarray):
-        try:
-            obj = obj.__array__()
-        except AttributeError:
-            raise TypeError("expected an ndarray-compatible object, got %r"
-                            % (type(obj,)))
-        assert isinstance(obj, np.ndarray)
-    return obj
+cdef extern from "Python.h":
+    bytearray PyByteArray_FromStringAndSize(char *v, Py_ssize_t l)
+    char* PyByteArray_AS_STRING(object string)
+    object PyUnicode_FromStringAndSize(const char *u, Py_ssize_t size)
+    int PyUnicode_Check(object text)
 
 
-def _check_1d_object_array(np.ndarray arr):
-    if arr.ndim != 1:
-        raise TypeError("expected a 1d array")
-    if arr.dtype != _obj_dtype:
-        raise TypeError("expected an object array")
-
-
-def array_encode_utf8(inp):
-    """
-    utf-8 encode all elements of a 1d ndarray of "object" dtype.
-    A new ndarray of bytes objects is returned.
-    """
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def encodeutf8(buf):
     cdef:
-        Py_ssize_t i, n
-        np.ndarray[object] arr
-        np.ndarray[object] result
+        Py_ssize_t i, l, n_items, data_length, total_length
+        object[:] input_values
+        object[:] encoded_values
+        int[:] encoded_lengths
+        char* encv
+        bytes b
+        bytearray out
+        char* data
+        object u
 
-    arr = _to_array(inp)
-    _check_1d_object_array(arr)
+    # normalise input
+    input_values = np.asanyarray(buf, dtype=object).reshape(-1, order='A')
 
-    n = len(arr)
-    result = np.empty(n, dtype=object)
-    for i in range(n):
-        # Fast utf-8 encoding, avoiding method call and codec lookup indirection
-        result[i] = PyUnicode_AsUTF8String(arr[i])
+    # determine number of items
+    n_items = input_values.shape[0]
 
-    return result
+    # setup intermediates
+    encoded_values = np.empty(n_items, dtype=object)
+    encoded_lengths = np.empty(n_items, dtype=np.intc)
 
+    # first iteration to convert to bytes
+    data_length = 0
+    for i in range(n_items):
+        u = input_values[i]
+        if not PyUnicode_Check(u):
+            raise TypeError('expected unicode string, found %r' % u)
+        b = PyUnicode_AsUTF8String(u)
+        l = PyBytes_GET_SIZE(b)
+        encoded_values[i] = b
+        data_length += l + 4  # 4 bytes to store item length
+        encoded_lengths[i] = l
 
-def array_decode_utf8(inp):
-    """
-    utf-8 decode all elements of a 1d ndarray of "object" dtype.
-    A new ndarray of unicode objects is returned.
-    """
-    cdef:
-        Py_ssize_t i, n
-        np.ndarray[object] arr
-        np.ndarray[object] result
-        object val
+    # setup output
+    total_length = data_length
+    out = PyByteArray_FromStringAndSize(NULL, total_length)
 
-    arr = _to_array(inp)
-    _check_1d_object_array(arr)
+    # write header
+    data = PyByteArray_AS_STRING(out)
 
-    n = len(arr)
-    result = np.empty(n, dtype=object)
-    for i in range(n):
-        val = arr[i]
-        if not PyBytes_CheckExact(val):
-            raise TypeError("expected array of bytes")
-        # Fast utf-8 decoding, avoiding method call and codec lookup indirection
-        result[i] = PyUnicode_DecodeUTF8(
-            PyBytes_AS_STRING(val),
-            PyBytes_GET_SIZE(val),
-            NULL,   # errors
-            )
-
-    return result
-
-
-def pack_byte_array(list items):
-    """
-    Pack a variable length byte array column.
-    A bytes object is returned.
-    """
-    cdef:
-        Py_ssize_t i, n, itemlen, total_size
-        unsigned char *start
-        unsigned char *data
-        object val, out
-
-    # Strategy: compute the total output size and allocate it in one go.
-    n = len(items)
-    total_size = 0
-    for i in range(n):
-        val = items[i]
-        if not PyBytes_CheckExact(val):
-            raise TypeError("expected list of bytes")
-        total_size += 4 + PyBytes_GET_SIZE(val)
-
-    out = PyBytes_FromStringAndSize(NULL, total_size)
-    start = data = <unsigned char *> PyBytes_AS_STRING(out)
-
-    # Copy data to output.
-    for i in range(n):
-        val = items[i]
-        # `itemlen` should be >= 0, so no signed extension issues
-        itemlen = PyBytes_GET_SIZE(val)
-        data[0] = itemlen & 0xff
-        data[1] = (itemlen >> 8) & 0xff
-        data[2] = (itemlen >> 16) & 0xff
-        data[3] = (itemlen >> 24) & 0xff
+    # second iteration, store data
+    for i in range(n_items):
+        l = encoded_lengths[i]
+        data[0] = l & 0xff
+        data[1] = (l >> 8) & 0xff
+        data[2] = (l >> 16) & 0xff
+        data[3] = (l >> 24) & 0xff
         data += 4
-        memcpy(data, PyBytes_AS_STRING(val), itemlen)
-        data += itemlen
+        encv = PyBytes_AS_STRING(encoded_values[i])
+        memcpy(data, encv, l)
+        data += l
 
-    assert (data - start) == total_size
+    return bytes(out)
+
+
+def encodebytes():
+    pass
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def decodeutf8(buf, int n_items):
+    cdef:
+        Buffer input_buffer
+        char* data
+        char* data_end
+        Py_ssize_t i, l, data_length, input_length
+
+    # accept any buffer
+    input_buffer = Buffer(buf, PyBUF_ANY_CONTIGUOUS)
+    input_length = input_buffer.nbytes
+
+
+    # obtain input data pointer
+    data = input_buffer.ptr
+    data_end = data + input_length
+
+    # setup output
+    out = np.empty(n_items, dtype=object)
+
+    # iterate and decode - N.B., do not try to cast `out` as object[:]
+    # as this causes segfaults, possibly similar to
+    # https://github.com/cython/cython/issues/1608
+    for i in range(n_items):
+        if data + 4 > data_end:
+            raise ValueError('corrupt buffer, data seem truncated')
+        l = (data[0] + (data[1] << 8) +
+             (data[2] << 16) + (data[3] << 24))
+        data += 4
+        if data + l > data_end:
+            raise ValueError('corrupt buffer, data seem truncated')
+        out[i] = PyUnicode_FromStringAndSize(data, l)
+        data += l
+
     return out
 
 
-def unpack_byte_array(bytes raw_bytes, Py_ssize_t n):
-    """
-    Unpack a variable length byte array column.
-    A list of bytes objects is returned.  RuntimeError is raised
-    if *raw_bytes* contents don't exactly match *n*.
-    """
+def decodebytes():
+    pass
+
+
+cdef class Buffer:
+    """Compatibility class to work around fact that array.array does not support
+    new-style buffer interface in PY2."""
     cdef:
-        Py_ssize_t i, itemlen, remaining
-        unsigned char *start
-        unsigned char *data
-        list out
+        char *ptr
+        Py_buffer buffer
+        size_t nbytes
+        size_t itemsize
+        array.array arr
+        bint new_buffer
+        bint released
 
-    start = data = <unsigned char *> PyBytes_AS_STRING(raw_bytes)
-    remaining = PyBytes_GET_SIZE(raw_bytes)
-    out = [None] * n
+    def __cinit__(self, obj, flags):
+        self.released = False
+        if hasattr(obj, 'dtype'):
+            if obj.dtype.kind in 'Mm':
+                obj = obj.view('u8')
+            elif obj.dtype.kind == 'O':
+                raise ValueError('cannot obtain buffer from object array')
+        if PY2 and isinstance(obj, array.array):
+            self.new_buffer = False
+            self.arr = obj
+            self.ptr = <char *> self.arr.data.as_voidptr
+            self.itemsize = self.arr.itemsize
+            self.nbytes = self.arr.buffer_info()[1] * self.itemsize
+        else:
+            self.new_buffer = True
+            PyObject_GetBuffer(obj, &(self.buffer), flags)
+            self.ptr = <char *> self.buffer.buf
+            self.itemsize = self.buffer.itemsize
+            self.nbytes = self.buffer.len
 
-    for i in range(n):
-        remaining -= 4
-        # It is required to check this inside the loop to avoid
-        # out of bounds array accesses.
-        if remaining < 0:
-            raise RuntimeError("Ran out of input")
-        itemlen = (data[0] + (data[1] << 8) +
-                   (data[2] << 16) + (data[3] << 24))
-        data += 4
+    cpdef release(self):
+        if self.new_buffer and not self.released:
+            PyBuffer_Release(&(self.buffer))
+            self.released = True
 
-        remaining -= itemlen
-        if remaining < 0:
-            raise RuntimeError("Ran out of input")
-        out[i] = PyBytes_FromStringAndSize(<char *> data, itemlen)
-        data += itemlen
-
-    return out
+    def __dealloc__(self):
+        self.release()

--- a/fastparquet/test/test_converted_types.py
+++ b/fastparquet/test/test_converted_types.py
@@ -64,17 +64,6 @@ def test_timestamp_millis():
                 dtype='datetime64[ns]'))
 
 
-def test_utf8():
-    """Test bytes representing utf-8 string."""
-    schema = pt.SchemaElement(
-        type=pt.Type.BYTE_ARRAY,
-        name="test",
-        converted_type=pt.ConvertedType.UTF8
-    )
-    data = b'\xc3\x96rd\xc3\xb6g'
-    assert convert(pd.Series([data]), schema)[0] == u"Ördög"
-
-
 def test_json():
     """Test bytes representing json."""
     schema = pt.SchemaElement(
@@ -82,8 +71,8 @@ def test_json():
         name="test",
         converted_type=pt.ConvertedType.JSON
     )
-    assert convert(pd.Series([b'{"foo": ["bar", "\\ud83d\\udc7e"]}']),
-                          schema)[0] == {'foo': ['bar', u'👾']}
+    assert convert(pd.Series(['{"foo": ["bar", "\\ud83d\\udc7e"]}']),
+                   schema)[0] == {'foo': ['bar', u'👾']}
 
 
 @pytest.mark.skipif(PY2,reason='BSON unicode may not be supported in Python 2')

--- a/fastparquet/test/test_encoding.py
+++ b/fastparquet/test/test_encoding.py
@@ -41,10 +41,11 @@ def test_double():
 def test_fixed():
     """Test reading bytes containing fixed bytes data."""
     data = b"foobar"
+    se = parquet_thrift.SchemaElement(converted_type=None)
     assert data[:3] == fastparquet.encoding.read_plain(
-            data, parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY, -1, 3)[0]
+            data, parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY, -1, 3, se)[0]
     assert data[3:] == fastparquet.encoding.read_plain(
-            data, parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY, -1, 3)[1]
+            data, parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY, -1, 3, se)[1]
 
 def test_boolean():
     """Test reading bytes containing boolean data."""

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -515,7 +515,7 @@ def test_auto_null(tempdir):
     test_cols = list(set(df) - set(object_cols)) + ['d']
     fn = os.path.join(tmp, "test.parq")
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, TypeError)):
         write(fn, df, has_nulls=False)
 
     write(fn, df, has_nulls=True)
@@ -799,9 +799,9 @@ def test_append_w_partitioning(tempdir):
 
 def test_bad_object_encoding(tempdir):
     df = pd.DataFrame({'x': ['a', 'ab']})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises((ValueError, TypeError)) as e:
         write(str(tempdir), df, object_encoding='utf-8')
-    assert "utf-8" in str(e)
+    assert "unicode" in str(e)
 
 
 def test_empty_dataframe(tempdir):
@@ -879,14 +879,12 @@ def test_consolidate_cats(tempdir):
 
 def test_bad_object_encoding(tempdir):
     df = pd.DataFrame({'a': [b'00']})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises((ValueError, TypeError)) as e:
         write(tempdir, df, file_scheme='hive', object_encoding='utf8')
-    assert "UTF8" in str(e)
-    assert "bytes" in str(e)
-    assert '"a"' in str(e)
+    assert "unicode" in str(e)
 
     df = pd.DataFrame({'a': [0, "hello", 0]})
-    with pytest.raises(ValueError) as e:
+    with pytest.raises((ValueError, TypeError)) as e:
         write(tempdir, df, file_scheme='hive', object_encoding='int')
     assert "INT64" in str(e)
     assert "primitive" in str(e)

--- a/fastparquet/test/test_speedups.py
+++ b/fastparquet/test/test_speedups.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import struct
+import pytest
 
 from fastparquet.speedups import encode, decode
 
@@ -17,6 +18,15 @@ def test_encode_bytes():
     expected = b''.join([(struct.pack('<i', len(s)) + s) for s in bytess])
     result = encode(bytess, utf8=False)
     assert expected == result
+
+
+def test_error():
+    with_bad = strings + [1]
+    with pytest.raises(TypeError):
+        encode(with_bad, utf8=True)
+    with_bad = bytess + [1]
+    with pytest.raises(TypeError):
+        encode(with_bad, utf8=False)
 
 
 def test_decode_bytes():

--- a/fastparquet/test/test_speedups.py
+++ b/fastparquet/test/test_speedups.py
@@ -2,125 +2,43 @@
 
 import struct
 
-import pytest
-
-import numpy as np
-
-import pandas as pd
-import pandas.util.testing as tm
-
-from fastparquet.speedups import (
-    array_encode_utf8, array_decode_utf8,
-    pack_byte_array, unpack_byte_array
-    )
-from fastparquet.util import PY2, PY3
+from fastparquet.speedups import encode, decode
 
 strings = [u"abc", u"a\x00c", u"héhé", u"プログラミング"]
+bytess = [s.encode('utf8') for s in strings]
 
 
-def test_array_encode_utf8():
-    arr = np.array(strings, dtype='object')
-    expected = [s.encode('utf-8') for s in strings]
-    got = array_encode_utf8(arr)
-
-    assert got.dtype == np.dtype('object')
-    assert list(got) == expected
-
-    ser = pd.Series(arr)
-    got = array_encode_utf8(ser)
-
-    assert got.dtype == np.dtype('object')
-    assert list(got) == expected
-
-    # Wrong array type
-    arr = np.array(strings, dtype='U')
-    with pytest.raises((TypeError, ValueError)):
-        array_encode_utf8(arr)
-
-    # Disabled for v2
-    if PY3:
-        # Non-encodable string (lone surrogate)
-        # on py2 this works anyway
-        invalid_string = u"\uDE80"
-        arr = np.array(strings + [invalid_string], dtype='object')
-        with pytest.raises(UnicodeEncodeError):
-            array_encode_utf8(arr)
-
-    # Wrong object type
-    arr = np.array([b"foo"], dtype='object')
-    with pytest.raises(TypeError):
-        array_encode_utf8(arr)
+def test_roundtrip_bytes():
+    out = decode(encode(bytess, utf8=False), len(bytess), utf8=False).tolist()
+    assert out == bytess
 
 
-def test_array_decode_utf8():
-    bytestrings = [s.encode('utf-8') for s in strings]
-
-    arr = np.array(bytestrings, dtype='object')
-    expected = list(strings)
-    got = array_decode_utf8(arr)
-
-    assert got.dtype == np.dtype('object')
-    assert list(got) == expected
-
-    # Non-decodable string
-    arr = np.array(bytestrings + [b"\x00\xff"], dtype='object')
-    with pytest.raises(UnicodeDecodeError):
-        array_decode_utf8(arr)
-
-    # Wrong array type
-    arr = np.array(bytestrings, dtype='S')
-    with pytest.raises((TypeError, ValueError)):
-        array_decode_utf8(arr)
-
-    # Wrong object type
-    arr = np.array([u"foo"], dtype='object')
-    with pytest.raises(TypeError):
-        array_decode_utf8(arr)
+def test_encode_bytes():
+    expected = b''.join([(struct.pack('<i', len(s)) + s) for s in bytess])
+    result = encode(bytess, utf8=False)
+    assert expected == result
 
 
-def test_pack_byte_array():
-    bytestrings = [b"foo", b"bar\x00" * 256 + b"z"]
-
-    expected = b''.join(struct.pack('<L', len(b)) + b
-                        for b in bytestrings)
-
-    b = pack_byte_array(bytestrings)
-    assert b == expected
-
-    b = pack_byte_array([])
-    assert b == b''
-
-    with pytest.raises(TypeError):
-        pack_byte_array(tuple(bytestrings))
-
-    with pytest.raises(TypeError):
-        pack_byte_array(bytestrings + [u"foo"])
-
-    with pytest.raises(TypeError):
-        pack_byte_array(b"foo")
+def test_decode_bytes():
+    data = b''.join([(struct.pack('<i', len(s)) + s) for s in bytess])
+    out = decode(data, len(bytess), utf8=False).tolist()
+    assert out == bytess
 
 
-def test_unpack_byte_array():
-    bytestrings = [b"foo", b"bar\x00" * 256 + b"z"]
+def test_roundtrip_utf():
+    out = decode(encode(strings, utf8=True), len(strings), utf8=True).tolist()
+    assert out == strings
 
-    packed = b''.join(struct.pack('<L', len(b)) + b
-                      for b in bytestrings)
 
-    seq = unpack_byte_array(packed, len(bytestrings))
-    assert seq == bytestrings
+def test_encode_utf():
+    expected = b''.join([(struct.pack('<i', len(s.encode('utf8'))) +
+                          s.encode('utf8')) for s in strings])
+    result = encode(strings, utf8=True)
+    assert expected == result
 
-    def check_invalid_length(b, n):
-        with pytest.raises(RuntimeError):
-            unpack_byte_array(b, n)
 
-    check_invalid_length(packed, len(bytestrings) + 1)
-    check_invalid_length(packed[:-1], len(bytestrings))
-    check_invalid_length(packed[:-1], len(bytestrings))
-
-    # Extra bytes silently ignored
-    seq = unpack_byte_array(packed, len(bytestrings) - 1)
-    assert seq == bytestrings[:-1]
-    seq = unpack_byte_array(packed + b'\x00', len(bytestrings))
-    assert seq == bytestrings
-    seq = unpack_byte_array(packed + b'\x01\x02\x03\x04', len(bytestrings))
-    assert seq == bytestrings
+def test_decode_utf():
+    data = b''.join([(struct.pack('<i', len(s.encode('utf8'))) +
+                      s.encode('utf8')) for s in strings])
+    out = decode(data, len(strings), utf8=True).tolist()
+    assert out == strings

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -183,6 +183,8 @@ def convert(data, se):
             elif converted_type == parquet_thrift.ConvertedType.BSON:
                 out = data.map(tobson).values
             if type == parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY:
+                if converted_type == parquet_thrift.ConvertedType.UTF8:
+                    out = np.char.encode(out.astype("U"), 'utf8')
                 out = out.astype('S%i' % se.type_length)
         except Exception as e:
             ct = parquet_thrift.ConvertedType._VALUES_TO_NAMES[

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1] in allowed):
 else:
     import numpy as np
     from Cython.Build import cythonize
+    import Cython.Compiler.Options
+    Cython.Compiler.Options.annotate = True
     cython_modules = [Extension('fastparquet.speedups',
                                 ['fastparquet/speedups.pyx'],
                                 include_dirs=[np.get_include()])]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
     import numpy as np
     from Cython.Build import cythonize
     import Cython.Compiler.Options
-    Cython.Compiler.Options.annotate = True
+    Cython.Compiler.Options.annotate = False
     cython_modules = [Extension('fastparquet.speedups',
                                 ['fastparquet/speedups.pyx'],
                                 include_dirs=[np.get_include()])]


### PR DESCRIPTION
Strings en/decoding speedups inspired by https://github.com/alimanfoo/numcodecs/blob/e94a182e28d47b0e3a8aecd902b9e82f48b720b2/numcodecs/vlen.pyx (see [discussion](https://github.com/alimanfoo/numcodecs/pull/56))

Benchmarks (time taken, smaller is better):
branch
utf8: read, fixed: 6 162.019
utf8: read, fixed: None 122.684
utf8: write, fixed: 6 169.497
utf8: write, fixed: 6, nostat 111.139
utf8: write, fixed: None 83.332
utf8: write, fixed: None, nostat 29.057

master:
utf8: read, fixed: 6 174.109
utf8: read, fixed: None 182.614
utf8: write, fixed: 6 148.194
utf8: write, fixed: None 154.619

"nostat" is the new option not to bother creating column metadata statistics.

The most common codepath is UTF8 read, not fixed: 180->120ms, good gain.

cc @alimanfoo