### PR TITLE
Get `setup.py pytest` to work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 *.dll
 fastparquet/speedups.c
 .coverage
+.eggs
 cover
 build
 dist
-parquet.egg-info
+fastparquet.egg-info
 .idea
 .cached
 /.cache

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,19 @@ import os
 import sys
 try:
     from setuptools import setup, Extension
+    from setuptools.command.build_ext import build_ext as _build_ext
 except ImportError:
     from distutils.core import setup, Extension
+    from distutils.command.build_ext import build_ext as _build_ext
+
+# Kudos to https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py/21621689
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 allowed = ('--help-commands', '--version', 'egg_info', 'clean')
 if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1] in allowed):
@@ -13,12 +24,26 @@ if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1] in allowed):
     # so pip can install fastparquet when these requirements are not available.
     extra = {}
 else:
-    import numpy as np
-    from Cython.Build import cythonize
-    cython_modules = [Extension('fastparquet.speedups',
-                                ['fastparquet/speedups.pyx'],
-                                include_dirs=[np.get_include()])]
-    extra = {'ext_modules': cythonize(cython_modules)}
+    modules_to_build = {
+        'fastparquet.speedups': ['fastparquet/speedups.pyx']
+    }
+    try:
+        from Cython.Build import cythonize
+        def fix_exts(sources):
+            return sources
+    except ImportError:
+        def cythonize(modules):
+            return modules
+        def fix_exts(sources):
+            return [s.replace('.pyx', '.c') for s in sources]
+
+    modules = [
+        Extension(mod, fix_exts(sources))
+        for mod, sources in modules_to_build.items()]
+
+    extra = {'ext_modules': cythonize(modules)}
+
+install_requires = open('requirements.txt').read().strip().split('\n')
 
 setup(
     name='fastparquet',
@@ -42,7 +67,16 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     packages=['fastparquet'],
-    install_requires=[open('requirements.txt').read().strip().split('\n')],
+    cmdclass={'build_ext':build_ext},
+    install_requires=install_requires,
+    setup_requires=[
+        'pytest-runner',
+        [p for p in install_requires if p.startswith('numpy')][0]
+    ],
+    tests_require=[
+        'pytest',
+        'python-snappy',
+    ],
     long_description=(open('README.rst').read() if os.path.exists('README.rst')
                       else ''),
     package_data={'fastparquet': ['*.thrift']},


### PR DESCRIPTION
This patch modifies setup.py so that:

1. `setup.py pytest` works.
2. On first run of any setup command involving a build, let setuptools automatically install numpy so the build will go without a hustle.
3. It no longer requires Cython if the user just wants to install fastparquet.