### PR TITLE
Integrate pytest with setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = -x

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,13 @@ setup(
                       else ''),
     package_data={'fastparquet': ['*.thrift']},
     include_package_data=True,
+    tests_require=[
+        'pytest',
+        'python-snappy',
+    ],
+    setup_requires=[
+        'pytest-runner',
+    ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     **extra
 )


### PR DESCRIPTION
This integrates pytest with setuptools to enable running of the tests with a simple `python setup.py test`