### PR TITLE
Add handling of keyword arguments for compressor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ install:
   - conda install -c conda-forge thrift python-snappy
   - conda install numpy pandas numba cython setuptools
   - pip install bson
-
+  - pip install lz4
+  
 script:
   - pip install -e .
   - py.test -x -vv --pyargs fastparquet

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   
 script:
   - python setup.py install
-  - py.test -x -vv --pyargs fastparquet
+  - python setup.py test
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - pip install lz4
   
 script:
-  - pip install -e .
+  - python setup.py install
   - py.test -x -vv --pyargs fastparquet
 
 notifications:

--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -5,8 +5,6 @@ from .util import PY2
 
 # TODO: use stream/direct-to-buffer conversions instead of memcopy
 
-# TODO: enable ability to pass kwargs to compressor
-
 compressions = {
     'UNCOMPRESSED': lambda x: x
 }
@@ -71,14 +69,29 @@ rev_map = {getattr(parquet_thrift.CompressionCodec, key): key for key in
            ['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI', 'LZ4']}
 
 
-def compress_data(data, algorithm='gzip'):
+#def compress_data(data, algorithm='gzip'):
+def compress_data(data, compression='gzip'):
+    if isinstance(compression, dict):
+        algorithm = compression.get('type', 'gzip')
+        if isinstance(algorithm, int):
+            algorithm = rev_map[compression]
+        args = compression.get('args', None)
+    else:
+        algorithm = compression
+        args = None
+
     if isinstance(algorithm, int):
-        algorithm = rev_map[algorithm]
+        algorithm = rev_map[compression]
+
     if algorithm.upper() not in compressions:
         raise RuntimeError("Compression '%s' not available.  Options: %s" %
                 (algorithm, sorted(compressions)))
-    return compressions[algorithm.upper()](data)
-
+    if args is None:
+        return compressions[algorithm.upper()](data)
+    else:
+        if not isinstance(args, dict):
+            raise ValueError("args dict entry is not a dict")
+        return compressions[algorithm.upper()](data, **args)
 
 def decompress_data(data, algorithm='gzip'):
     if isinstance(algorithm, int):

--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -69,7 +69,6 @@ rev_map = {getattr(parquet_thrift.CompressionCodec, key): key for key in
            ['UNCOMPRESSED', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI', 'LZ4']}
 
 
-#def compress_data(data, algorithm='gzip'):
 def compress_data(data, compression='gzip'):
     if isinstance(compression, dict):
         algorithm = compression.get('type', 'gzip')

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -386,6 +386,7 @@ def test_bad_file_paths(tempdir):
     assert out.a.tolist() == ['x', 'y', 'z'] * 2
 
 def test_compression(tempdir):
+    pytest.importorskip('lz4')
     df = pd.DataFrame(
         {
             'x': np.arange(1000),

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -384,3 +384,48 @@ def test_bad_file_paths(tempdir):
     pf = ParquetFile([fn1, fn2])
     out = pf.to_pandas()
     assert out.a.tolist() == ['x', 'y', 'z'] * 2
+
+def test_compression(tempdir):
+    df = pd.DataFrame(
+        {
+            'x': np.arange(1000),
+            'y': np.arange(1, 1001),
+            'z': np.arange(2, 1002),
+        }
+    )
+
+    fn = os.path.join(tempdir, 'foocomp.parquet')
+
+    c = {
+        "x": {
+            "type": "gzip",
+            "args": {
+                "compresslevel": 5,
+            }
+        },
+        "y": {
+            "type": "lz4",
+            "args": {
+                "compression_level": 5,
+                "content_checksum": True,
+                "block_size": 0,
+                "block_checksum": True,
+                "block_linked": True,
+                "store_size": True,
+            }
+        },
+        "_default": {
+            "type": "snappy",
+            "args": None
+        }
+    }
+    write(fn, df, compression=c)
+
+    p = ParquetFile(fn)
+
+    df2 = p.to_pandas()
+
+    assert (False in set(df2["x"] == df["x"])) is False
+    assert (False in set(df2["y"] == df["y"])) is False
+    assert (False in set(df2["z"] == df["z"])) is False
+

--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -7,7 +7,7 @@ import pytest
 @pytest.mark.parametrize('fmt', compressions)
 def test_compress_decompress_roundtrip(fmt):
     data = b'123' * 1000
-    compressed = compress_data(data, algorithm=fmt)
+    compressed = compress_data(data, compression=fmt)
     if fmt.lower() == 'uncompressed':
         assert compressed is data
     else:
@@ -19,7 +19,7 @@ def test_compress_decompress_roundtrip(fmt):
 
 def test_errors():
     with pytest.raises(RuntimeError) as e:
-        compress_data(b'123', algorithm='not-an-algorithm')
+        compress_data(b'123', compression='not-an-algorithm')
 
     assert 'not-an-algorithm' in str(e)
     assert 'gzip' in str(e).lower()
@@ -28,5 +28,5 @@ def test_errors():
 def test_not_installed():
     compressions.pop('BROTLI', None)
     with pytest.raises(RuntimeError) as e:
-        compress_data(b'123', algorithm=4)
+        compress_data(b'123', compression=4)
     assert 'brotli' in str(e.value).lower()

--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -17,6 +17,23 @@ def test_compress_decompress_roundtrip(fmt):
     assert data == decompressed
 
 
+def test_compress_decompress_roundtrip_args_gzip():
+    data = b'123' * 1000
+    compressed = compress_data(
+        data,
+        compression={
+            "type": "gzip",
+            "args": {
+                "compresslevel": 5,
+            }
+        }
+    )
+    assert len(compressed) < len(data)
+
+    decompressed = decompress_data(compressed, algorithm="gzip")
+    assert data == decompressed
+
+
 def test_errors():
     with pytest.raises(RuntimeError) as e:
         compress_data(b'123', compression='not-an-algorithm')

--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -34,6 +34,7 @@ def test_compress_decompress_roundtrip_args_gzip():
     assert data == decompressed
 
 def test_compress_decompress_roundtrip_args_lz4():
+    pytest.importorskip('lz4')
     data = b'123' * 1000
     compressed = compress_data(
         data,

--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -33,6 +33,26 @@ def test_compress_decompress_roundtrip_args_gzip():
     decompressed = decompress_data(compressed, algorithm="gzip")
     assert data == decompressed
 
+def test_compress_decompress_roundtrip_args_lz4():
+    data = b'123' * 1000
+    compressed = compress_data(
+        data,
+        compression={
+            "type": "lz4",
+            "args": {
+                "compression_level": 5,
+                "content_checksum": True,
+                "block_size": 0,
+                "block_checksum": True,
+                "block_linked": True,
+                "store_size": True,
+            }
+        }
+    )
+    assert len(compressed) < len(data)
+
+    decompressed = decompress_data(compressed, algorithm="lz4")
+    assert data == decompressed
 
 def test_errors():
     with pytest.raises(RuntimeError) as e:

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -418,8 +418,12 @@ def write_column(f, data, selement, compression=None):
     data: pandas Series or numpy (1d) array
     selement: thrift SchemaElement
         produced by ``find_type``
-    compression: str or None
-        if not None, must be one of the keys in ``compression.compress``
+    compression: str, dict, or None
+        if ``str``, must be one of the keys in ``compression.compress``
+        if ``dict``, must have key ``"type"`` which specifies the compression
+        type to use, which must be one of the keys in ``compression.compress``,
+        and may optionally have key ``"args`` which should be a dictionary of
+        options to pass to the underlying compression engine.
 
     Returns
     -------
@@ -553,12 +557,17 @@ def write_column(f, data, selement, compression=None):
             page_type=parquet_thrift.PageType.DATA_PAGE,
             encoding=parquet_thrift.Encoding.PLAIN, count=1)]
 
+    if isinstance(compression, dict):
+        algorithm = compression.get("type", None)
+    else:
+        algorithm = compression
+
     cmd = parquet_thrift.ColumnMetaData(
             type=selement.type, path_in_schema=[name],
             encodings=[parquet_thrift.Encoding.RLE,
                        parquet_thrift.Encoding.BIT_PACKED,
                        parquet_thrift.Encoding.PLAIN],
-            codec=(getattr(parquet_thrift.CompressionCodec, compression.upper())
+            codec=(getattr(parquet_thrift.CompressionCodec, algorithm.upper())
                    if compression else 0),
             num_values=tot_rows,
             statistics=s,
@@ -597,6 +606,8 @@ def make_row_group(f, data, schema, compression=None):
         if column.type is not None:
             if isinstance(compression, dict):
                 comp = compression.get(column.name, None)
+                if comp is None:
+                    comp = compression.get('_default', None)
             else:
                 comp = compression
             chunk = write_column(f, data[column.name], column,
@@ -732,6 +743,32 @@ def write(filename, data, row_group_offsets=50000000,
         values to start new row groups.
     compression: str, dict
         compression to apply to each column, e.g. GZIP or SNAPPY or
+        {col1: "SNAPPY", col2: None} to specify per column compression types.
+        In both cases, the compressor settings would be the underlying
+        compressor defaults. To pass arguments to the underlying compressor,
+        each ``dict`` entry should itself be a dictionary::
+
+            {
+                col1: {
+                    "type": "LZ4",
+                    "args": {
+                        "compression_level": 6,
+                        "content_checksum": True
+                     }
+                },
+                col2: {
+                    "type": "SNAPPY",
+                    "args": None
+                }
+                "_default": {
+                    "type": "GZIP",
+                    "args": None
+                }
+            }
+
+        If the dictionary contains a "_default" entry, this will be used for any
+        columns not explicitly specified in the dictionary.
+    GZIP or SNAPPY or
         {col1: "SNAPPY", col2: None} to specify per column.
     file_scheme: 'simple'|'hive'
         If simple: all goes in a single file

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -568,7 +568,7 @@ def write_column(f, data, selement, compression=None):
                        parquet_thrift.Encoding.BIT_PACKED,
                        parquet_thrift.Encoding.PLAIN],
             codec=(getattr(parquet_thrift.CompressionCodec, algorithm.upper())
-                   if compression else 0),
+                   if algorithm else 0),
             num_values=tot_rows,
             statistics=s,
             data_page_offset=start,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 test=pytest
 
 [tool:pytest]
-addopts = -x
+addopts = -x -vv

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     tests_require=[
         'pytest',
         'python-snappy',
-        'lz4',
+        'lz4 >= 0.19.1',
     ],
     long_description=(open('README.rst').read() if os.path.exists('README.rst')
                       else ''),


### PR DESCRIPTION
This adds support for passing a dictionary of properties through to the compressor which are passed to the compressor as a keyword argument list. This design doesn't break backwards compatibility.

The later commits require the LZ4 capability from PR #292 - that should be merged first.