### PR TITLE
Remove annoying print() when reading file with CategoricalDtype index

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -79,7 +79,6 @@ def empty(types, size, cats=None, cols=None, index_type=None, index_name=None,
             else:  # explicit labels list
                 c = Categorical([], categories=cats[index_name],
                                 fastpath=True)
-            print(cats, index_name, c)
             vals = np.empty(size, dtype=c.codes.dtype)
             index = CategoricalIndex(c)
             index._data._codes = vals


### PR DESCRIPTION
See https://github.com/dask/fastparquet/issues/310