### PR TITLE
Fix typo in ParquetFile docstring

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -71,7 +71,7 @@ class ParquetFile(object):
         Thrift objects for each row group
     schema: schema.SchemaHelper
         print this for a representation of the column structure
-    self_made: bool
+    selfmade: bool
         If this file was created by fastparquet
     statistics: dict
         Max/min/count of each column chunk


### PR DESCRIPTION
The [documentation for ParquetFile](https://fastparquet.readthedocs.io/en/latest/api.html#fastparquet.ParquetFile) mentions the attribute `self_made`, but in the code it's [`selfmade`](https://github.com/dask/fastparquet/blob/master/fastparquet/api.py#L139):

```py
        self.selfmade = self.created_by.split(' ', 1)[0] == "fastparquet-python"
```