### PR TITLE
Buildfix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include fastparquet *.thrift
 recursive-include fastparquet *.py
 recursive-include fastparquet *.pyx
+recursive-include fastparquet *.c
 recursive-include docs *.rst
 
 include setup.py

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,13 @@ except ImportError:
 # Kudos to https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py/21621689
 class build_ext(_build_ext):
     def finalize_options(self):
+        if sys.version_info[0] >= 3:
+            import builtins
+        else:
+            import __builtin__ as builtins
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 


### PR DESCRIPTION
* Include `speedup.c` in the source distribution. Otherwise the build fails when it's built from the source archive.
* `setup.py` can be executed as a imported (non-main) module by setuptools when setuptools builds the dependencies and in such cases `__builtins__` points to a builtins dict instead of builtins module. 