### PR TITLE
Fix _dtypes to be more efficient, to work with files with lots of columns

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -449,26 +449,24 @@ class ParquetFile(object):
         """ Implied types of the columns in the schema """
         if categories is None:
             categories = self.categories
-        dtype = {name: (converted_types.typemap(f)
-                          if f.num_children in [None, 0] else np.dtype("O"))
-                 for name, f in self.schema.root.children.items()}
-
-        chunks_list = [[c for c in rg.columns] for rg in self.row_groups]
+        dtype = OrderedDict((name, (converted_types.typemap(f)
+                            if f.num_children in [None, 0] else np.dtype("O")))
+                            for name, f in self.schema.root.children.items())
         for i, (col, dt) in enumerate(dtype.copy().items()):
             if dt.kind in ['i', 'b']:
                 # int/bool columns that may have nulls become float columns
                 num_nulls = 0
-
-                # Get correct list of chunks
-                chunks = [cs[i] for cs in chunks_list]
-                for chunk in chunks:
+                for rg in self.row_groups:
+                    chunk = rg.columns[i]
                     if chunk.meta_data.statistics is None:
                         num_nulls = True
                         break
                     if chunk.meta_data.statistics.null_count is None:
                         num_nulls = True
                         break
-                    num_nulls += chunk.meta_data.statistics.null_count
+                    if chunk.meta_data.statistics.null_count:
+                        num_nulls = True
+                        break
                 if num_nulls:
                     if dtype[col].itemsize == 1:
                         dtype[col] = np.dtype('f2')

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -454,10 +454,13 @@ class ParquetFile(object):
                  for name, f in self.schema.root.children.items()}
 
         chunks_list = [[c for c in rg.columns] for rg in self.row_groups]
-        for (col, dt), chunks in zip(dtype.copy().items(), chunks_list):
+        for i, (col, dt) in enumerate(dtype.copy().items()):
             if dt.kind in ['i', 'b']:
                 # int/bool columns that may have nulls become float columns
                 num_nulls = 0
+
+                # Get correct list of chunks
+                chunks = [cs[i] for cs in chunks_list]
                 for chunk in chunks:
                     if chunk.meta_data.statistics is None:
                         num_nulls = True


### PR DESCRIPTION
This seems to address at least a good chunk of #317.  For the test case in question, simply computing the column names once cuts a large chunk of the time.  It doesn't fully close the gap between fastparquet and pyarrow in this case, so I'm sure there's more that can be done, but this is a start at least:
```
import fastparquet
file = 'test_head.parq'
%prun pf = fastparquet.ParquetFile(file)
  
240602 function calls (230394 primitive calls) in 5.567 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     5556    5.224    0.001    5.224    0.001 api.py:466(<listcomp>)
        1    0.138    0.138    0.174    0.174 {built-in method thrift.protocol.fastbinary.decode_compact}
        1    0.052    0.052    5.301    5.301 api.py:448(_dtypes)
  10207/1    0.037    0.000    0.053    0.053 schema.py:28(schema_to_text)
        1    0.014    0.014    0.014    0.014 decoder.py:345(raw_decode)
        1    0.010    0.010    0.019    0.019 schema.py:52(flatten)
    10206    0.010    0.000    0.010    0.000 ttypes.py:1357(__init__)
```