### PR TITLE
numba bool fun

### DIFF
--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -31,6 +31,7 @@ def time_column():
                           'y': r / np.random.randint(1, 1000, size=n),
                           'z': np.random.randint(0, 127, size=n,
                                                  dtype=np.uint8)})
+        d['b'] = r > 0
 
         for col in d.columns:
             df = d[[col]]

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -13,10 +13,23 @@ from .thrift_structures import parquet_thrift
 from .util import byte_buffer
 
 
+@numba.njit(nogil=True)
+def unpack_boolean(data, out):
+    for i in range(len(data)):
+        d = data[i]
+        for j in range(8):
+            out[i * 8 + j] = d & 1
+            d >>= 1
+
+
 def read_plain_boolean(raw_bytes, count):
     """Read `count` booleans using the plain encoding."""
-    return np.unpackbits(np.frombuffer(raw_bytes, dtype=np.uint8)).reshape(
-            (-1, 8))[:, ::-1].ravel().astype(bool)[:count]
+    data = np.frombuffer(raw_bytes, dtype='uint8')
+    padded = (8 * (count // 8) + 8 if count % 8 > 0 else count)
+    out = np.empty(padded, dtype=bool)
+    unpack_boolean(data, out)
+    return out[:count]
+
 
 DECODE_TYPEMAP = {
     parquet_thrift.Type.INT32: np.int32,

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -25,7 +25,7 @@ def unpack_boolean(data, out):
 def read_plain_boolean(raw_bytes, count):
     """Read `count` booleans using the plain encoding."""
     data = np.frombuffer(raw_bytes, dtype='uint8')
-    padded = (8 * (count // 8) + 8 if count % 8 > 0 else count)
+    padded = len(raw_bytes) * 8
     out = np.empty(padded, dtype=bool)
     unpack_boolean(data, out)
     return out[:count]


### PR DESCRIPTION
A nice little example of a handy speedup by going numpy->numba.

The benchmark for bool reads (no NULL) goes from 17ms to 7ms.