### PR TITLE
Robust partition names

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -28,6 +28,12 @@ class ParquetFile(object):
     Reads the metadata (row-groups and schema definition) and provides
     methods to extract the data from the files.
 
+    Note that when reading parquet files partitioned using directories
+    (i.e. using the hive/drill scheme), an attempt is made to coerce
+    the partition values to a number, datetime or timedelta. Fastparquet
+    cannot read a hive/drill parquet file with partition names which coerce
+    to the same value, such as "0.7" and ".7".
+
     Parameters
     ----------
     fn: path/URL string or list of paths
@@ -63,7 +69,7 @@ class ParquetFile(object):
     file_scheme: str
         'simple': all row groups are within the same file; 'hive': all row
         groups are in other files; 'mixed': row groups in this file and others
-        too; 'empty': no row grops at all.
+        too; 'empty': no row groups at all.
     info: dict
         Combination of some of the other attributes
     key_value_metadata: list

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -9,6 +9,7 @@ import json
 import os
 import six
 import struct
+import warnings
 
 import numpy as np
 from fastparquet.util import join_path
@@ -18,7 +19,7 @@ from .thrift_structures import parquet_thrift
 from . import core, schema, converted_types, encoding, dataframe
 from .util import (default_open, ParquetException, val_to_num,
                    ensure_bytes, check_column_names, metadata_from_many,
-                   ex_from_sep, get_file_scheme, STR_TYPE)
+                   ex_from_sep, get_file_scheme, STR_TYPE, groupby_types)
 
 
 class ParquetFile(object):
@@ -172,6 +173,7 @@ class ParquetFile(object):
             self.cats = {}
             return
         cats = OrderedDict()
+        raw_cats = OrderedDict()
         for rg in self.row_groups:
             for col in rg.columns:
                 s = ex_from_sep('/')
@@ -179,12 +181,31 @@ class ParquetFile(object):
                 if self.file_scheme == 'hive':
                     partitions = s.findall(path)
                     for key, val in partitions:
-                        cats.setdefault(key, set()).add(val)
+                        cats.setdefault(key, set()).add(val_to_num(val))
+                        raw_cats.setdefault(key, set()).add(val)
                 else:
                     for i, val in enumerate(col.file_path.split('/')[:-1]):
                         key = 'dir%i' % i
                         cats.setdefault(key, set()).add(val)
-        self.cats = OrderedDict([(key, list([val_to_num(x) for x in v]))
+                        raw_cats.setdefault(key, set()).add(val_to_num(val))
+
+        for key, v in cats.items():
+            # Check that no partition names map to the same value after transformation by val_to_num
+            raw = raw_cats[key]
+            if len(v) != len(raw):
+                conflicts_by_value = OrderedDict()
+                for raw_val in raw_cats[key]:
+                    conflicts_by_value.setdefault(val_to_num(raw_val), set()).add(raw_val)
+                conflicts = [c for k in conflicts_by_value.values() if len(k) > 1 for c in k]
+                raise ValueError("Partition names map to the same value: %s" % conflicts)
+            vals_by_type = groupby_types(v)
+
+            # Check that all partition names map to the same type after transformation by val_to_num
+            if len(vals_by_type) > 1:
+                examples = [x[0] for x in vals_by_type.values()]
+                warnings.warn("Partition names coerce to values of different types, e.g. %s" % examples)
+
+        self.cats = OrderedDict([(key, list(v))
                                 for key, v in cats.items()])
 
     def row_group_filename(self, rg):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -192,8 +192,8 @@ class ParquetFile(object):
                 else:
                     for i, val in enumerate(col.file_path.split('/')[:-1]):
                         key = 'dir%i' % i
-                        cats.setdefault(key, set()).add(val)
-                        raw_cats.setdefault(key, set()).add(val_to_num(val))
+                        cats.setdefault(key, set()).add(val_to_num(val))
+                        raw_cats.setdefault(key, set()).add(val)
 
         for key, v in cats.items():
             # Check that no partition names map to the same value after transformation by val_to_num

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -247,6 +247,13 @@ def test_numerical_partition_name(tempdir):
     assert out[out.y1 == 'aa'].x.tolist() == [1, 5, 5]
     assert out[out.y1 == 'bb'].x.tolist() == [2]
 
+def test_floating_point_partition_name(tempdir):
+    df = pd.DataFrame({'x': [1e99, 5e-10, 2e+2, -0.1], 'y1': ['aa', 'aa', 'bb', 'aa']})
+    write(tempdir, df, file_scheme='hive', partition_on=['y1'])
+    pf = ParquetFile(tempdir)
+    out = pf.to_pandas()
+    assert out[out.y1 == 'aa'].x.tolist() == [1e99, 5e-10, -0.1]
+    assert out[out.y1 == 'bb'].x.tolist() == [200.0]
 
 def test_datetime_partition_names(tempdir):
     date_strings = ['2015-05-09', '2018-10-15', '2020-10-17', '2015-05-09']

--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -82,15 +82,20 @@ def test_val_to_num():
     assert val_to_num('0') == 0
     assert val_to_num('00') == 0
     assert val_to_num('-20') == -20
+    assert val_to_num(7) == 7
+    assert val_to_num(0.7) == 0.7
+    assert val_to_num(0) == 0
     assert val_to_num('NOW') == 'NOW'
     assert val_to_num('now') == 'now'
     assert val_to_num('TODAY') == 'TODAY'
+    assert val_to_num('') == ''
     assert val_to_num('2018-10-10') == pd.to_datetime('2018-10-10')
     assert val_to_num('2018-10-09') == pd.to_datetime('2018-10-09')
     assert val_to_num('2017-12') == pd.to_datetime('2017-12')
-    assert val_to_num('5e6') == '5e6'
+    assert val_to_num('5e+6') == 5e6
+    assert val_to_num('5e-6') == 5e-6
+    assert val_to_num('0xabc') == '0xabc'
     assert val_to_num('hello world') == 'hello world'
-    assert val_to_num('') == ''
     # The following tests document an idiosyncrasy of val_to_num which is difficult
     # to avoid while timedeltas are supported.
     assert val_to_num('50+20') == pd.to_timedelta('50+20')

--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 import pytest
 
-from fastparquet.util import analyse_paths, get_file_scheme, val_to_num, join_path
+from fastparquet.util import analyse_paths, get_file_scheme, val_to_num, join_path, groupby_types
 
 
 def test_analyse_paths():
@@ -95,3 +95,10 @@ def test_val_to_num():
     assert val_to_num('50+20') == pd.to_timedelta('50+20')
     assert val_to_num('50-20') == pd.to_timedelta('50-20')
 
+
+def test_groupby_types():
+    assert len(groupby_types([1, 2, 3])) == 1
+    assert len(groupby_types(["1", "2", "3.0"])) == 1
+    assert len(groupby_types([1, 2, 3.0])) == 2
+    assert len(groupby_types([1, "2", "3.0"])) == 2 
+    assert len(groupby_types([pd.to_datetime("2000"), "2000"])) == 2

--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -1,4 +1,5 @@
 import os
+import pandas as pd
 import pytest
 
 from fastparquet.util import analyse_paths, get_file_scheme, val_to_num, join_path
@@ -80,3 +81,17 @@ def test_val_to_num():
     assert val_to_num('07') == 7
     assert val_to_num('0') == 0
     assert val_to_num('00') == 0
+    assert val_to_num('-20') == -20
+    assert val_to_num('NOW') == 'NOW'
+    assert val_to_num('TODAY') == 'TODAY'
+    assert val_to_num('2018-10-10') == pd.to_datetime('2018-10-10')
+    assert val_to_num('2018-10-09') == pd.to_datetime('2018-10-09')
+    assert val_to_num('2017-12') == pd.to_datetime('2017-12')
+    assert val_to_num('5e6') == '5e6'
+    assert val_to_num('hello world') == 'hello world'
+    assert val_to_num('') == ''
+    # The following tests document an idiosyncrasy of val_to_num which is difficult
+    # to avoid while timedeltas are supported.
+    assert val_to_num('50+20') == pd.to_timedelta('50+20')
+    assert val_to_num('50-20') == pd.to_timedelta('50-20')
+

--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -83,6 +83,7 @@ def test_val_to_num():
     assert val_to_num('00') == 0
     assert val_to_num('-20') == -20
     assert val_to_num('NOW') == 'NOW'
+    assert val_to_num('now') == 'now'
     assert val_to_num('TODAY') == 'TODAY'
     assert val_to_num('2018-10-10') == pd.to_datetime('2018-10-10')
     assert val_to_num('2018-10-09') == pd.to_datetime('2018-10-09')

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -40,7 +40,7 @@ def default_open(f, mode='rb'):
 
 def val_to_num(x):
     """Parse a string as a number, date or timedelta if possible, otherwise return the string"""
-    if x in ['NOW', 'TODAY', '']:
+    if x in ['now', 'NOW', 'TODAY', '']:
         return x
     if set(x) == {'0'}:
         # special case for values like "000"

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -16,7 +16,7 @@ PY2 = six.PY2
 PY3 = six.PY3
 STR_TYPE = six.string_types[0]  # 'str' for Python3, 'basestring' for Python2
 created_by = "fastparquet-python version 1.0.0 (build 111)"
-
+DISALLOWED_LITERAL_CHARACTERS = "+boxjeBOXJE_'\""
 
 class ParquetException(Exception):
     """Generic Exception related to unexpected data format when
@@ -38,13 +38,14 @@ def default_open(f, mode='rb'):
 
 
 def val_to_num(x):
-    if x in ['NOW', 'TODAY']:
+    """Parse a string as a number, date or timedelta if possible, otherwise return the string"""
+    if x in ['NOW', 'TODAY', '']:
         return x
     if set(x) == {'0'}:
         # special case for values like "000"
         return 0
     try:
-        return ast.literal_eval(x.lstrip('0'))
+        return _parse_literal(x)
     except:
         pass
     try:
@@ -56,6 +57,15 @@ def val_to_num(x):
     except:
         return x
 
+def _parse_literal(x):
+    """ Parse a subset of possible numeric literals """
+    if any(c in x for c in DISALLOWED_LITERAL_CHARACTERS):
+        raise ValueError("Characters in [%s] are not allowed" % DISALLOWED_LITERAL_CHARACTERS)
+    # Allow '-' at the start of the string for negative numbers
+    if '-' in x[1:]:
+        raise ValueError('dashes (-) not allowed inside of numeric literal')
+
+    return ast.literal_eval(x.lstrip('0'))
 
 if PY2:
     def ensure_bytes(s):

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -5,6 +5,7 @@ import os.path
 import pandas as pd
 import re
 import six
+from collections import defaultdict
 
 try:
     from pandas.api.types import is_categorical_dtype
@@ -208,6 +209,11 @@ def infer_dtype(column):
     except AttributeError:
         return pd.lib.infer_dtype(column)
 
+def groupby_types(iterable):
+    groups = defaultdict(list)
+    for x in iterable:
+        groups[type(x)].append(x)
+    return groups
 
 def get_column_metadata(column, name):
     """Produce pandas column metadata block"""

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -45,6 +45,10 @@ def val_to_num(x):
     if set(x) == {'0'}:
         # special case for values like "000"
         return 0
+    if x == "True":
+        return True
+    if x == "False":
+        return False
     try:
         return _parse_literal(x)
     except:


### PR DESCRIPTION
w.r.t: #335 

The primary purpose of this diff is to ensure that partition names such as `2018-10-10` get parsed as dates instead of integer literals when reading hive-partitioned parquet files.

More specifically:
- Partition names containing any of `+boxjeBOXJE_'"` are no longer parsed as string literals. I would be extremely surprised if anyone was relying on scientific notation, imaginary numbers, arithmetic, etc. in partition names
- If any two partition names map to the same value e.g. `"0.7"` and `".7"` or `"may 9 2018"` and `"2018-05-09"`, an informative ValueError is thrown
- If any the number of types encountered in the partition values after transformation by `val_to_num()` is greater than 1, a warning is displayed.

(There's also a new test for filtering by dates.)

As discussed in the issue, a future feature could be added to enable/disable this inference entirely, either across all partitions or on a per-name basis. However, I think it would be good to at least get this in for now.