### PR TITLE
Move pytest-runner and numpy from setup_requires to install requires in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,9 @@ else:
 
 install_requires = open('requirements.txt').read().strip().split('\n')
 
+# add pytest-runner from setup_requires
+install_requires.append('pytest-runner')
+
 setup(
     name='fastparquet',
     version='0.1.5',
@@ -73,10 +76,11 @@ setup(
     packages=['fastparquet'],
     cmdclass={'build_ext': build_ext},
     install_requires=install_requires,
-    setup_requires=[
-        'pytest-runner',
-        [p for p in install_requires if p.startswith('numpy')][0]
-    ],
+    # remove wierd setup_requires to get rid of easy_install
+    # setup_requires=[
+    #    'pytest-runner',
+    #    [p for p in install_requires if p.startswith('numpy')][0]
+    #],
     tests_require=[
         'pytest',
         'python-snappy',


### PR DESCRIPTION
There is an issue with setup_requires when installing the packages not from pypi (for example in our office we use artifactory instead). When you're doing pip install fastparquet it tries to install packages from setup_requires by easy_install from the default source (pypi) ignoring all the configs. If you don't have access to pypi the setup fails although you do have all the sources for requirements at the artifactory. I've moved packages from setup_requires to install_requires thus they are installed by pip with respect to pip.conf.