### PR TITLE
Deep digging for multi-indexes

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -393,7 +393,7 @@ class ParquetFile(object):
             Category-type column, potentially saving memory and time. If a
             dict {col: int}, the value indicates the number of categories,
             so that the optimal data-dtype can be allocated. If ``None``,
-            will automatically set *if* the data was written by fastparquet.
+            will automatically set *if* the data was written from pandas.
         filters: list of tuples
             To filter out (i.e., not read) some of the row-groups.
             (This is not row-level filtering)

--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -13,7 +13,7 @@ decompressions = {
 }
 
 # Gzip is present regardless
-COMPRESSION_LEVEL = 9
+COMPRESSION_LEVEL = 6
 if PY2:
     def gzip_compress_v2(data, compresslevel=COMPRESSION_LEVEL):
         from io import BytesIO

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -18,6 +18,25 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
     """
     Create empty DataFrame to assign into
 
+    In the simplest case, will return a Pandas dataframe of the given size,
+    with columns of the given names and types. The second return value `views`
+    is a dictionary of numpy arrays into which you can assign values that
+    show up in the dataframe.
+
+    For categorical columns, you get two views to assign into: if the
+    column name is "col", you get both "col" (the category codes) and
+    "col-catdef" (the category labels).
+
+    For a single categorical index, you should use the `.set_categories`
+    method of the appropriate "-catdef" columns, passing an Index of values
+
+    ``views['index-catdef'].set_categories(pd.Index(newvalues), fastpath=True)``
+
+    Multi-indexes work a lot like categoricals, even if the types of each
+    index are not themselves categories, and will also have "-catdef" entries
+    in the views. However, these will be Dummy instances, providing only a
+    ``.set_categories`` method, to be used as above.
+
     Parameters
     ----------
     types: like np record structure, 'i4,u2,f4,f2,f4,M8,m8', or using tuples
@@ -33,6 +52,12 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
         is missing, will assume 16-bit integers (a reasonable default).
     cols: list of labels
         assigned column names, including categorical ones.
+    index_types: list of str
+        For one of more index columns, make them have this type. See general
+        description, above, for caveats about multi-indexing. If None, the
+        index will be the default RangeIndex.
+    index_names: list of str
+        Names of the index column(s), if using
     timezones: dict {col: timezone_str}
         for timestamp type columns, apply this timezone to the pandas series;
         the numpy view will be UTC.

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -672,3 +672,37 @@ def test_unicode_cols(tempdir):
     write(fn, df)
     pf = ParquetFile(fn)
     pf.to_pandas()
+
+
+def test_multi_cat(tempdir):
+    fn = os.path.join(tempdir, 'test.parq')
+    N = 200
+    df = pd.DataFrame(
+        {'a': np.random.randint(10, size=N),
+         'b': np.random.choice(['a', 'b', 'c'], size=N),
+         'c': np.arange(200)})
+    df['a'] = df.a.astype('category')
+    df['b'] = df.b.astype('category')
+    df = df.set_index(['a', 'b'])
+    write(fn, df)
+
+    pf = ParquetFile(fn)
+    df1 = pf.to_pandas()
+    assert df1.equals(df)
+    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])
+
+
+def test_multi(tempdir):
+    fn = os.path.join(tempdir, 'test.parq')
+    N = 200
+    df = pd.DataFrame(
+        {'a': np.random.randint(10, size=N),
+         'b': np.random.choice(['a', 'b', 'c'], size=N),
+         'c': np.arange(200)})
+    df = df.set_index(['a', 'b'])
+    write(fn, df)
+
+    pf = ParquetFile(fn)
+    df1 = pf.to_pandas()
+    assert df1.equals(df)
+    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])

--- a/fastparquet/test/test_aroundtrips.py
+++ b/fastparquet/test/test_aroundtrips.py
@@ -73,10 +73,8 @@ df = sql.read.json('temp.json')
 @pytest.mark.parametrize('row_groups', [[0], [0, 500]])
 @pytest.mark.parametrize('comp', [None] + list(compressions))
 def test_pyspark_roundtrip(tempdir, scheme, row_groups, comp, sql):
-    if comp == 'BROTLI':
-        pytest.xfail("spark doesn't support BROTLI compression")
-    if comp == 'ZSTD':
-        pytest.xfail("spark doesn't support ZSTD compression")
+    if comp in ['BROTLI', 'ZSTD', 'LZO', "LZ4"]:
+        pytest.xfail("spark doesn't support compression")
     data = pd.DataFrame({'i32': np.random.randint(-2**17, 2**17, size=1001,
                                                   dtype=np.int32),
                          'i64': np.random.randint(-2**33, 2**33, size=1001,

--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from fastparquet.dataframe import empty
 
 

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -334,4 +334,4 @@ def test_multi_index_category(tempdir):
     assert dg.index.levels[0].name == 'a'
     assert dg.index.levels[0].dtype == '<M8[ns]'
     assert dg.index.levels[1].name == 'b'
-    assert dg.index.levels[1].is_categorical()
+    assert dg.equals(df)


### PR DESCRIPTION
Fixes https://github.com/dask/fastparquet/issues/349
Fixes https://github.com/pandas-dev/pandas/issues/21949
Supersedes #353 

Note that this really should be applied only to data that was pandas-born, where we can guarantee that the index columns were sensible on the way in. Currently produces a warning if the column in question was not originally categorical.
However, for categorical columns, you don't actually get a categorical index, because in the multi-index case it is pointless (you already have label encoding). Thus, you don't *quite* round-trip, but I think this is good enough.