### PR TITLE
Add optional compression requirements to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,13 @@ setup(
     #    'pytest-runner',
     #    [p for p in install_requires if p.startswith('numpy')][0]
     #],
+    extras_require={
+        'brotli': ['brotli'],
+        'lz4': ['lz4 >= 0.19.1'],
+        'lzo': ['python-lzo'],
+        'snappy': ['python-snappy'],
+        'zstandard': ['zstandard']
+    },
     tests_require=[
         'pytest',
         'python-snappy',


### PR DESCRIPTION
Adds the optional compression packages as extra requirements. Allows for simple installation of optionals ex ``pip install fastparquet[snappy]``.