### PR TITLE
Don't mutate column list input (#383)

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -413,7 +413,7 @@ class ParquetFile(object):
         size = sum(rg.num_rows for rg in rgs)
         index = self._get_index(index)
         if columns is not None:
-            columns = columns.copy()
+            columns = columns[:]
         else:
             columns = self.columns
         if index:

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -412,7 +412,10 @@ class ParquetFile(object):
         rgs = self.filter_row_groups(filters)
         size = sum(rg.num_rows for rg in rgs)
         index = self._get_index(index)
-        columns = columns or self.columns
+        if columns is not None:
+            columns = columns.copy()
+        else:
+            columns = self.columns
         if index:
             columns += [i for i in index if i not in columns]
         check_column_names(self.columns + list(self.cats), columns, categories)

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -447,6 +447,14 @@ def test_no_index_name(tempdir):
     assert out.index.name is None
     assert out.index.tolist() == [0, 1, 2]
 
+def test_input_column_list_not_mutated(tempdir):
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    write(tempdir, df, file_scheme='hive')
+    cols = ['a']
+    pf = ParquetFile(tempdir)
+    out = pf.to_pandas(columns=cols)
+    assert cols == ['a']
+
 
 def test_drill_list(tempdir):
     df = pd.DataFrame({'a': ['x', 'y', 'z'], 'b': [4, 5, 6]})


### PR DESCRIPTION
Fixes #383.

When a list of columns to read is passed to `ParquetFile.to_pandas()`, this no longer mutates the provided list.