### PR TITLE
Change OverflowError message when failing on large pages

### DIFF
--- a/fastparquet/thrift_structures.py
+++ b/fastparquet/thrift_structures.py
@@ -5,6 +5,7 @@ from thrift.protocol.TCompactProtocol import TCompactProtocolAccelerated as TCom
 from thrift.protocol.TProtocol import TProtocolException
 
 from .parquet_thrift.parquet import ttypes as parquet_thrift
+from .util import ParquetException
 
 
 def read_thrift(file_obj, ttype):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -546,8 +546,8 @@ def write_column(f, data, selement, compression=None):
     try:
         write_thrift(f, ph)
     except OverflowError as err:
-        raise IOError('Overflow error while writing page; try using row groups '
-                      'or smaller ones if you already are. Original message: ' +
+        raise IOError('Overflow error while writing page; try using a smaller '
+                      'value for `row_group_offsets`. Original message: ' +
                       str(err))
 
     f.write(bdata)

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -543,8 +543,13 @@ def write_column(f, data, selement, compression=None):
                                    uncompressed_page_size=l0,
                                    compressed_page_size=l1,
                                    data_page_header=dph, crc=None)
+    try:
+        write_thrift(f, ph)
+    except OverflowError as err:
+        raise IOError('Overflow error while writing page; try using row groups '
+                      'or smaller ones if you already are. Original message: ' +
+                      str(err))
 
-    write_thrift(f, ph)
     f.write(bdata)
 
     compressed_size = f.tell() - start


### PR DESCRIPTION
Currently, when writing a row group that's too big, all we see is an `OverflowError` exception. This is really confusing when writing string columns, as reported in #348 and #338.

This PR saves us some agony in debugging those problems by catching the exception and rethrowing it as an `IOError` with a more helpful error message.

I also included a fix in this PR for a bug I found in `thrift_structures.py` where we're throwing a `ParquetException` but not importing it first.