### PR TITLE
Compat for pandas 0.24.0 refactor

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -149,7 +149,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             new_block = block.make_block_same_class(values=values)
         elif getattr(block.dtype, 'tz', None):
             new_shape = (size, )
-            values = np.empty(shape=new_shape, dtype=block.values.values.dtype)
+            values = np.empty(shape=new_shape, dtype="M8[ns]")
             new_block = block.make_block_same_class(
                     values=values, dtype=block.values.dtype)
         else:
@@ -174,7 +174,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 views[col] = block.values._codes
                 views[col+'-catdef'] = block.values
             elif getattr(block.dtype, 'tz', None):
-                views[col] = block.values.values
+                views[col] = np.asarray(block.values, dtype='M8[ns]')
             else:
                 views[col] = block.values[i]
 


### PR DESCRIPTION
In https://github.com/pandas-dev/pandas/pull/24024, pandas is changing
the internal structure of DatetimeTZBlock.

Previously, DatetimeTZBlock.values was a DatetimeIndex. Now it's a
DatetimeArray. Anywhere we access DatetimeTZBlock.values.values will
now break, since DatetimeArray doesn't expose a `.values`.

Using `np.asarray(DatetimeArray, dtype="M8[ns]")` is a backwards and
forwards compatiable way of converting a tz aware or naive
DatetimeArray to an ndarray.

Closes https://github.com/dask/fastparquet/issues/388