### PR TITLE
Fix failing Windows tests

### DIFF
--- a/fastparquet/test/test_partition_filters_specialstrings.py
+++ b/fastparquet/test/test_partition_filters_specialstrings.py
@@ -66,6 +66,9 @@ def frame_symbol_dtTrade_type_strike(days=1 * 252,
 def test_frame_write_read_verify(tempdir, input_symbols, input_days,
                                  file_scheme,
                                  input_columns, partitions, filters):
+    if os.name == 'nt':
+        pytest.xfail("Partitioning folder names contain special characters which are not supported on Windows")
+
     # Generate Temp Director for parquet Files
     fdir = str(tempdir)
     fname = os.path.join(fdir, 'test')

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -319,7 +319,7 @@ def test_multi_index(tempdir):
     assert dg.index.levels[0].name == 'a'
     assert dg.index.levels[0].dtype == '<M8[ns]'
     assert dg.index.levels[1].name == 'b'
-    assert dg.index.levels[1].dtype == int
+    assert dg.index.levels[1].dtype == np.int64
 
 
 def test_multi_index_category(tempdir):


### PR DESCRIPTION
Closes #395

In the end there were only two tests failing on Windows. The first one was `test_frame_write_read_verify` failing due to Windows not supporting special characters in folder names. The fix was to allow the test to fail on Windows as discussed in #395. The second fix was to change `test_multi_index` to compare `dtype` against `np.int64` instead of `int`. For some reason on Windows they are not the same. I tried updating Numpy but it didn't solve the issue.