### PR TITLE
Revert #345 restoring numpy to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,6 @@ else:
 
 install_requires = open('requirements.txt').read().strip().split('\n')
 
-# add pytest-runner from setup_requires
-install_requires.append('pytest-runner')
-
 setup(
     name='fastparquet',
     version='0.2.1',
@@ -76,11 +73,10 @@ setup(
     packages=['fastparquet'],
     cmdclass={'build_ext': build_ext},
     install_requires=install_requires,
-    # remove wierd setup_requires to get rid of easy_install
-    # setup_requires=[
-    #    'pytest-runner',
-    #    [p for p in install_requires if p.startswith('numpy')][0]
-    #],
+    setup_requires=[
+        'pytest-runner',
+        [p for p in install_requires if p.startswith('numpy')][0]
+    ],
     extras_require={
         'brotli': ['brotli'],
         'lz4': ['lz4 >= 0.19.1'],


### PR DESCRIPTION
This reverts commit 14a6af65b96559d8834948bf32d375d864476b23 from #345.

`setup.p`y requires `setup_requires` including `numpy` - `numpy` must be installed
before the `fastparquet` wheel build.

The changes made in #345 and reverted here can be instead managed through
configuration of `distutils`.  This is outlined in https://pip.pypa.io/en/latest/reference/pip_install/#controlling-setup-requires and https://docs.python.org/3/install/index.html#distutils-configuration-files .

The change can be tested, including in-light of using a different index-server than `pypi.org`, by black-holing that host and setting-up a different local pypi server.

```
docker run -d --name devpi -p 3141:3141 scrapinghub/devpi

tee Dockerfile <<"EOF"
FROM python:3
  
ENV PIP_INDEX_URL=http://devpi:3141/root/pypi/+simple/
RUN echo "[easy_install]" >> $HOME/.pydistutils.cfg && \
    echo "index_url = http://devpi:3141/root/pypi/+simple/" >> $HOME/.pydistutils.cfg && \
    pip install --trusted-host devpi git+https://github.com/javabrett/fastparquet@revert-345-restore-setup-requires-numpy
EOF

docker build --no-cache --add-host devpi:172.17.0.2 --add-host pypi.org:0.42.42.42 -t fastparquet .
```

Fixes #389.

