### PR TITLE
Remove python 3 requirement from install docs

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,6 @@ Requirements
 
 Required:
 
-- python 3
 - numba
 - numpy
 - pandas


### PR DESCRIPTION
setup.py states that fastparquet is python3 compatible and the tests seem to pass on Travis with python2.7