### PR TITLE
Persist and read column index pandas metadata

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -7,7 +7,10 @@ from pandas.core.index import CategoricalIndex, RangeIndex, Index, MultiIndex
 from pandas.core.internals import BlockManager
 from pandas import Categorical, DataFrame, Series, __version__ as pdver
 from pandas.api.types import is_categorical_dtype
-from itertools import zip_longest
+try:
+    from itertools import zip_longest
+except ImportError:  # For python 2.7
+    from itertools import izip_longest as zip_longest
 import ast
 import operator
 import collections
@@ -78,6 +81,8 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
     timezones: dict {col: timezone_str}
         for timestamp type columns, apply this timezone to the pandas series;
         the numpy view will be UTC.
+    md: dict
+        Pandas metadata dictionary.  Used to reconstruct column index, if present.
 
     Returns
     -------

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -125,14 +125,6 @@ def test_roundtrip(tempdir, scheme, row_groups, comp):
         assert isinstance(data[col][0], type(df[col][0]))
 
 
-def test_bad_coltype(tempdir):
-    df = pd.DataFrame({'0': [1, 2], (0, 1): [3, 4]})
-    fn = os.path.join(tempdir, 'temp.parq')
-    with pytest.raises((ValueError, TypeError)) as e:
-        write(fn, df)
-        assert "tuple" in str(e)
-
-
 def test_bad_col(tempdir):
     df = pd.DataFrame({'x': [1, 2]})
     fn = os.path.join(tempdir, 'temp.parq')

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -10,6 +10,7 @@ import numpy as np
 import os
 
 import pandas as pd
+from pandas.util.testing import assert_frame_equal
 import pytest
 
 import fastparquet
@@ -421,3 +422,14 @@ def test_map_last_row_split(tempdir):
     assert sorted(df["topics"].iloc[1210].keys()) == sorted(first_split_row_keys)
     assert sorted(df["topics"].iloc[2427].keys()) == sorted(second_split_row_keys)
     assert df.isnull().sum().sum() == 0
+
+
+def test_column_index(tempdir):
+    from fastparquet import write, ParquetFile
+    column_index = pd.Index(['a', 'b'], name='column')
+    df = pd.DataFrame(np.random.random((4, 2)), columns=column_index)
+    output_file = os.path.join(tempdir, 'test_column_index.parq')
+    write(output_file, df)
+    pf = ParquetFile(output_file)
+    df2 = pf.to_pandas()
+    assert_frame_equal(df, df2)

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -433,3 +433,13 @@ def test_column_index(tempdir):
     pf = ParquetFile(output_file)
     df2 = pf.to_pandas()
     assert_frame_equal(df, df2)
+
+def test_multilevel_column_index(tempdir):
+    from fastparquet import write, ParquetFile
+    column_index_multi = pd.MultiIndex.from_tuples([('a', 'b'), ('a', 'c')], names=['level1', 'level2'])
+    df = pd.DataFrame(np.random.random((4,2)), columns=column_index_multi)
+    output_file = os.path.join(tempdir, 'test_column_index_multi.parq')
+    write(output_file, df)
+    pf = ParquetFile(output_file)
+    df2 = pf.to_pandas()
+    assert_frame_equal(df, df2)

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -235,7 +235,7 @@ def get_column_metadata(column, name):
     else:
         extra_metadata = None
 
-    if not isinstance(name, six.string_types):
+    if not isinstance(name, six.string_types) and name is not None:
         raise TypeError(
             'Column name must be a string. Got column {} of type {}'.format(
                 name, type(name).__name__

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -235,6 +235,10 @@ def get_column_metadata(column, name):
     else:
         extra_metadata = None
 
+    # Stringify multi-index 
+    if isinstance(name, tuple):
+        name = '{}'.format(name)
+
     if not isinstance(name, six.string_types) and name is not None:
         raise TypeError(
             'Column name must be a string. Got column {} of type {}'.format(

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -690,6 +690,9 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
             se.repetition_type = parquet_thrift.FieldRepetitionType.OPTIONAL
         fmd.schema.append(se)
         root.num_children += 1
+
+    pandas_metadata['column_indexes'] = [get_column_metadata(data.columns, data.columns.name)]
+
     meta.value = json.dumps(pandas_metadata, sort_keys=True)
     return fmd
 


### PR DESCRIPTION
This is to address issue #409, in which column index information (e.g., name of the index) had not previously been persisted in the pandas metadata dictionary.  This commit borrows code from pyarrow to both write this metadata (the 'column_indexes' field) and to use it in loading.  Note that this does not yet address the issue also mentioned in #409 where fastparquet breaks upon trying to write a dataframe with a multi-level column index.