### PR TITLE
Fix tz being None case

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -522,7 +522,7 @@ class ParquetFile(object):
                     else:
                         dtype[col] = np.dtype('f8')
             elif dt.kind == "M":
-                if tz.get(col, False):
+                if tz is not None and tz.get(col, False):
                     dtype[col] = pd.Series([], dtype='M8[ns]'
                                            ).dt.tz_localize(tz[col]).dtype
             elif dt == 'S12':


### PR DESCRIPTION
@martindurant 

Following up from below. Some tz None case. Probably someone should think about that logic, I *think* the boolean is correct like that but not 100%.

https://github.com/dask/fastparquet/issues/412