### PR TITLE
Undefined name: Typo in varliable name: wnd --> end

### DIFF
--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -341,7 +341,7 @@ def encode_rle_bp(data, width, o, withlength=False):
     if withlength:
         end = o.loc
         o.loc = start
-        write_length(wnd - start, o)
+        write_length(end - start, o)
         o.loc = end
 
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/dask/fastparquet on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./fastparquet/util.py:72:51: F821 undefined name 'unicode'
        return s.encode('utf-8') if isinstance(s, unicode) else s
                                                  ^
./fastparquet/util.py:102:12: F821 undefined name 'buffer'
    return buffer(raw_bytes) if PY2 else memoryview(raw_bytes)
           ^
./fastparquet/writer.py:220:36: F821 undefined name 'unicode'
    elif PY2 and all(isinstance(i, unicode) for i in head):
                                   ^
./fastparquet/writer.py:344:22: F821 undefined name 'wnd'
        write_length(wnd - start, o)
                     ^
./fastparquet/benchmarks/columns.py:144:23: F821 undefined name 'out'
    df = pd.DataFrame(out, columns=('type', 'nvalid', 'op', 'time'))
                      ^
5     F821 undefined name 'out'
5
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError