### PR TITLE
Disallow bad tz on save, warn on load

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -7,6 +7,7 @@ from pandas.core.internals import BlockManager
 from pandas import Categorical, DataFrame, Series, __version__ as pdver
 from pandas.api.types import is_categorical_dtype
 import six
+import warnings
 from .util import STR_TYPE
 
 
@@ -95,7 +96,12 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 t = t.base
             d = np.empty(0, dtype=t)
             if d.dtype.kind == "M" and six.text_type(col) in timezones:
-                d = Series(d).dt.tz_localize(timezones[six.text_type(col)])
+                try:
+                    d = Series(d).dt.tz_localize(timezones[six.text_type(col)])
+                except:
+                    warnings.warn("Inferring time-zone from %s in column %s "
+                                  "failed, using time-zone-agnostic"
+                                  "" % (timezones[six.text_type(col)], col))
             df[six.text_type(col)] = d
 
     df = DataFrame(df)

--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -2,7 +2,8 @@ import os
 import pandas as pd
 import pytest
 
-from fastparquet.util import analyse_paths, get_file_scheme, val_to_num, join_path, groupby_types
+from fastparquet.util import (analyse_paths, get_file_scheme, val_to_num,
+                              join_path, groupby_types, get_column_metadata)
 
 
 def test_analyse_paths():
@@ -108,3 +109,9 @@ def test_groupby_types():
     assert len(groupby_types([1, 2, 3.0])) == 2
     assert len(groupby_types([1, "2", "3.0"])) == 2 
     assert len(groupby_types([pd.to_datetime("2000"), "2000"])) == 2
+
+
+def test_bad_tz():
+    idx = pd.date_range('2012-01-01', periods=3, tz='dateutil/Europe/London')
+    with pytest.raises(ValueError):
+        get_column_metadata(idx, 'tz')

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -234,7 +234,12 @@ def get_column_metadata(column, name):
         }
         dtype = column.cat.codes.dtype
     elif hasattr(dtype, 'tz'):
-        extra_metadata = {'timezone': str(dtype.tz)}
+        try:
+            pd.Series([pd.to_datetime('now')]).dt.tz_localize(str(dtype.tz))
+            extra_metadata = {'timezone': str(dtype.tz)}
+        except Exception:
+            raise ValueError("Time-zone information could not be serialised: "
+                             "%s, please use another" % str(dtype.tz))
     else:
         extra_metadata = None
 


### PR DESCRIPTION
Fixes #424, where the string version of a tz is not something that
can then be used to set a timezone on loading