### PR TITLE
Handle NaN partition values

### DIFF
--- a/fastparquet/test/test_util.py
+++ b/fastparquet/test/test_util.py
@@ -90,6 +90,8 @@ def test_val_to_num():
     assert val_to_num('now') == 'now'
     assert val_to_num('TODAY') == 'TODAY'
     assert val_to_num('') == ''
+    assert val_to_num('nan') == 'nan'
+    assert val_to_num('NaN') == 'NaN'
     assert val_to_num('2018-10-10') == pd.to_datetime('2018-10-10')
     assert val_to_num('2018-10-09') == pd.to_datetime('2018-10-09')
     assert val_to_num('2017-12') == pd.to_datetime('2017-12')

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -44,6 +44,8 @@ def val_to_num(x):
         return x
     if x in ['now', 'NOW', 'TODAY', '']:
         return x
+    if type(x) == str and x.lower() == 'nan':
+        return x
     if x == "True":
         return True
     if x == "False":


### PR DESCRIPTION
I have a partitioned parquet file, one of those partition values (of type string) happens to be  `/lang=nan/`, which gets parses as `NaN` and then fails with `Partition names map to the same value: []`

Perhaps this is expected though.