### PR TITLE
Add field_name and creator to pandas_metadata

### DIFF
--- a/fastparquet/__init__.py
+++ b/fastparquet/__init__.py
@@ -4,11 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+__version__ = "0.3.2"
+
 from .thrift_structures import parquet_thrift
 from .core import read_thrift
 from .writer import write
 from . import core, schema, converted_types, api
 from .api import ParquetFile
 from .util import ParquetException
-
-__version__ = "0.3.2"

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -244,6 +244,7 @@ def get_column_metadata(column, name):
 
     return {
         'name': name,
+        'field_name': name,
         'pandas_type': {
             'string': 'bytes' if PY2 else 'unicode',
             'datetime64': (

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -22,7 +22,7 @@ except ImportError:
 from .thrift_structures import parquet_thrift
 from .compression import compress_data
 from .converted_types import tobson
-from . import encoding, api
+from . import encoding, api, __version__
 from .util import (default_open, default_mkdirs,
                    PY2, STR_TYPE,
                    check_column_names, metadata_from_many, created_by,
@@ -656,12 +656,15 @@ def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
                        'stop': index_cols._stop, 'step': index_cols._step,
                        'kind': 'range'}]
     pandas_metadata = {'index_columns': index_cols,
-                       'columns': [], 'pandas_version': pd.__version__,
+                       'columns': [],
                        'column_indexes': [{'name': data.columns.name,
                                            'field_name': data.columns.name,
                                            'pandas_type': 'mixed-integer',
                                            'numpy_type': 'object',
-                                           'metadata': None}]}
+                                           'metadata': None}],
+                       'creator': {'library': 'fastparquet',
+                                   'version': __version__},
+                       'pandas_version': pd.__version__,}
     root = parquet_thrift.SchemaElement(name='schema',
                                         num_children=0)
 


### PR DESCRIPTION
Closes https://github.com/dask/fastparquet/issues/462

While at it, I also added the "creator" key which was (at some point) also added to the pyarrow generated metadata.

Should this be tested somewhere? I didn't find tests that test the `pandas_metadata` explicitly (much of it is tested through actual behaviour tests I suppose,  but here it does not influence anything in fastparquet itself)