### PR TITLE
Use the python executable used to run the code

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import io
 import os
 import subprocess
+import sys
 from distutils.version import LooseVersion
 
 import numba
@@ -26,7 +27,7 @@ TEST_DATA = "test-data"
 @pytest.mark.skipif(numba.__version__ <= LooseVersion("0.39.0"), reason="Warning from numba.")
 def test_import_without_warning():
     # in a subprocess to avoid import chacing issues.
-    subprocess.check_call(["python", "-Werror", "-c", "import fastparquet"])
+    subprocess.check_call([sys.executable, "-Werror", "-c", "import fastparquet"])
 
 
 def test_statistics(tempdir):


### PR DESCRIPTION
Currently `test_import_without_warning` uses the system default python executable, `python`.  This, however, may not be the same as the python executable that was used to run the test, and another version may not have fastparquet available.  This patch changes it to use the same executable used to run the test.