### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
   include:
     - python: 3.6
     - python: 3.7
+    - python: 3.8
 
 install:
   # Install conda

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     packages=['fastparquet'],


### PR DESCRIPTION
I think this was previously blocked on Numba support for Python 3.8, which is now supported 

Closes #468