### PR TITLE
Add cramjam as extra

### DIFF
--- a/fastparquet/test/test_compression.py
+++ b/fastparquet/test/test_compression.py
@@ -33,6 +33,20 @@ def test_compress_decompress_roundtrip_args_gzip():
     decompressed = decompress_data(compressed, len(data), algorithm="gzip")
     assert data == decompressed
 
+
+@pytest.mark.parametrize("fmt", ("snappy", "brotli", "lz4", "gzip", "deflate", "zstd"))
+def test_compress_decompress_roundtrip_args_cramjam(fmt):
+    pytest.importorskip("cramjam")
+    data = b'123' * 1000
+    compressed = compress_data(
+        data,
+        compression={"type": fmt, "args": dict()}
+    )
+    assert len(compressed) < len(data)
+
+    decompressed = decompress_data(compressed, len(data), algorithm=fmt)
+    assert data == decompressed
+
 def test_compress_decompress_roundtrip_args_lz4():
     pytest.importorskip('lz4')
     data = b'123' * 1000

--- a/setup.py
+++ b/setup.py
@@ -83,13 +83,15 @@ setup(
         'lz4': ['lz4 >= 0.19.1'],
         'lzo': ['python-lzo'],
         'snappy': ['python-snappy'],
-        'zstandard': ['zstandard']
+        'zstandard': ['zstandard'],
+        'cramjam': ['cramjam']
     },
     tests_require=[
         'pytest',
         'python-snappy',
         'lz4 >= 0.19.1',
         'zstandard',
+        'cramjam'
     ],
     long_description=(open('README.rst').read() if os.path.exists('README.rst')
                       else ''),


### PR DESCRIPTION
Thanks for making this lib, it's so much lighter than pyarrow that it works quite nicely with AWS Lambda. However I ran into some snappy compressed parquet files at work, and found installing `python-snappy` inside Lambda to be painful.

Therefore, I threw together [cramjam](https://github.com/milesgranger/pyrus-cramjam) which is just a thin Python wrapper to various Rust de/compression formats.

The resulting `.whl` for the 6 supported formats ends up being ~1.5MB on linux, and was curious if this would be a welcomed PR as an alternative to things like `python-snappy`?

I'm sure there is a better way to organize `compressions.py` than what I've done here, but wanted input before going further.