### PR TITLE
support for numba > 0.48

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
       - libsnappy-dev
 
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -4,9 +4,17 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+
 import array
-import numba
+
 import numpy as np
+
+from packaging import version
+import numba
+if version.parse(numba.__version__) < version.parse("0.49"):
+    from numba import jitclass
+else:
+    from numba.experimental import jitclass
 
 from .speedups import unpack_byte_array
 from .thrift_structures import parquet_thrift

--- a/fastparquet/encoding.py
+++ b/fastparquet/encoding.py
@@ -227,9 +227,9 @@ class NumpyIO(object):  # pragma: no cover
         return self.data[:self.loc]
 
 spec8 = [('data', numba.uint8[:]), ('loc', numba.int64), ('len', numba.int64)]
-Numpy8 = numba.jitclass(spec8)(NumpyIO)
+Numpy8 = jitclass(spec8)(NumpyIO)
 spec32 = [('data', numba.uint32[:]), ('loc', numba.int64), ('len', numba.int64)]
-Numpy32 = numba.jitclass(spec32)(NumpyIO)
+Numpy32 = jitclass(spec32)(NumpyIO)
 
 
 def _assemble_objects(assign, defi, rep, val, dic, d, null, null_val, max_defi, prev_i):

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,7 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -95,6 +93,6 @@ setup(
                       else ''),
     package_data={'fastparquet': ['*.thrift']},
     include_package_data=True,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*,",
+    python_requires=">=3.6,",
     **extra
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, alternate-zstd
+envlist = py36, py37, py38, alternate-zstd
 usedevelop = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
In numba 0.49, jitclass is now found in `numba.experimental`.

closes #495 