### PR TITLE
deps: Add missing dependency on packaging.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas>=0.19
 numba>=0.28
 numpy>=1.11
+packaging
 thrift>=0.11.0
 six


### PR DESCRIPTION
Fixes #501.

```
$ python3 -m venv fastparquet

$ fastparquet/bin/pip install --upgrade pip
Collecting pip
  Using cached https://files.pythonhosted.org/packages/54/2e/df11ea7e23e7e761d484ed3740285a34e38548cf2bad2bed3dd5768ec8b9/pip-20.1-py2.py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 19.2.3
    Uninstalling pip-19.2.3:
      Successfully uninstalled pip-19.2.3
Successfully installed pip-20.1

$ fastparquet/bin/pip install -e $HOME/git/github.com/dask/fastparquet
Obtaining file:///$HOME/git/github.com/dask/fastparquet
Collecting pandas>=0.19
  Using cached pandas-1.0.3-cp37-cp37m-macosx_10_9_x86_64.whl (10.0 MB)
Collecting numba>=0.28
  Using cached numba-0.49.1-cp37-cp37m-macosx_10_14_x86_64.whl (2.1 MB)
Collecting numpy>=1.11
  Using cached numpy-1.18.4-cp37-cp37m-macosx_10_9_x86_64.whl (15.1 MB)
Collecting packaging
  Using cached packaging-20.3-py2.py3-none-any.whl (37 kB)
Collecting thrift>=0.11.0
  Using cached thrift-0.13.0.tar.gz (59 kB)
Collecting six
  Using cached six-1.14.0-py2.py3-none-any.whl (10 kB)
Collecting pytz>=2017.2
  Using cached pytz-2020.1-py2.py3-none-any.whl (510 kB)
Collecting python-dateutil>=2.6.1
  Using cached python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
Collecting llvmlite<=0.33.0.dev0,>=0.31.0.dev0
  Using cached llvmlite-0.32.1-cp37-cp37m-macosx_10_9_x86_64.whl (15.9 MB)
Requirement already satisfied: setuptools in ./fastparquet/lib/python3.7/site-packages (from numba>=0.28->fastparquet==0.4.0) (41.2.0)
Collecting pyparsing>=2.0.2
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Could not build wheels for fastparquet, since package wheel is not installed.
Could not build wheels for thrift, since package wheel is not installed.
Could not build wheels for setuptools, since package wheel is not installed.
Installing collected packages: pytz, six, python-dateutil, numpy, pandas, llvmlite, numba, pyparsing, packaging, thrift, fastparquet
    Running setup.py install for thrift ... done
  Running setup.py develop for fastparquet
Successfully installed fastparquet llvmlite-0.32.1 numba-0.49.1 numpy-1.18.4 packaging-20.3 pandas-1.0.3 pyparsing-2.4.7 python-dateutil-2.8.1 pytz-2020.1 six-1.14.0 thrift-0.13.0

$ fastparquet/bin/python -c "import fastparquet" && echo success
success
```