### PR TITLE
remove note about needing LLVM 4.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Requirements
 
 Required:
 
-- numba (requires `LLVM 4.0.x`_)
+- numba
 - numpy
 - pandas
 - cython


### PR DESCRIPTION
The comment was largely outdated, Numba currently runs on LLVM 9 and is
in the process of transitioning to LLVM 10. I think it will be best to
not specify any LLVM version dependencies in the README at all.