### PR TITLE
Fix writing parquet files with hive file schema

### DIFF
--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -96,13 +96,12 @@ def test_timestamps():
 
 
 def test_pandas_hive_serialization(tmpdir):
-    hive_test_temp_dir = tmpdir.mkdir("pandas_hive_test")
-    parquet_dir = hive_test_temp_dir.join("test.par")
+    parquet_dir = tmpdir.join("test.par")
     column = "data"
     df = pd.DataFrame(
         columns=[column], data=[("42",), ("",), ("0",), ("1",), ("0.0",)]
     )
     df.to_parquet(parquet_dir, file_scheme="hive", row_group_offsets=[0, 2, 4])
-    
+
     df_ = pd.read_parquet(parquet_dir)
     assert_frame_equal(df, df_)

--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -95,12 +95,14 @@ def test_timestamps():
     assert df.t2.dt.tz.zone == z2
 
 
-def test_pandas_hive_serialization():
+def test_pandas_hive_serialization(tmpdir):
+    hive_test_temp_dir = tmpdir.mkdir("pandas_hive_test")
+    parquet_dir = hive_test_temp_dir.join("test.par")
     column = "data"
     df = pd.DataFrame(
         columns=[column], data=[("42",), ("",), ("0",), ("1",), ("0.0",)]
     )
-    df.to_parquet("test.par", file_scheme="hive", row_group_offsets=[0, 2, 4])
-    df_ = pd.read_parquet("test.par")
+    df.to_parquet(parquet_dir, file_scheme="hive", row_group_offsets=[0, 2, 4])
+    
+    df_ = pd.read_parquet(parquet_dir)
     assert_frame_equal(df, df_)
-    shutil.rmtree("test.par")

--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -1,8 +1,10 @@
 import distutils
+import shutil
 import warnings
 
 import pytest
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from fastparquet.dataframe import empty
 
@@ -91,3 +93,14 @@ def test_timestamps():
                                                                   't2': z2})
     assert df.t1.dt.tz.zone == z
     assert df.t2.dt.tz.zone == z2
+
+
+def test_pandas_hive_serialization():
+    column = "data"
+    df = pd.DataFrame(
+        columns=[column], data=[("42",), ("",), ("0",), ("1",), ("0.0",)]
+    )
+    df.to_parquet("test.par", file_scheme="hive", row_group_offsets=[0, 2, 4])
+    df_ = pd.read_parquet("test.par")
+    assert_frame_equal(df, df_)
+    shutil.rmtree("test.par")

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -647,8 +647,12 @@ def make_part_file(f, data, schema, compression=None, fmd=None):
     return rg
 
 
-def make_metadata(data, has_nulls=True, ignore_columns=[], fixed_text=None,
-                  object_encoding=None, times='int64', index_cols=[]):
+def make_metadata(data, has_nulls=True, ignore_columns=None, fixed_text=None,
+                  object_encoding=None, times='int64', index_cols=None):
+    if ignore_columns is None:
+        ignore_columns = []
+    if index_cols is None:
+        index_cols = []
     if not data.columns.is_unique:
         raise ValueError('Cannot create parquet dataset with duplicate'
                          ' column names (%s)' % data.columns)


### PR DESCRIPTION
This relates to #510 

Pandas passes `None` for the `ignore_columns` parameter. This is not supported with the current implementation. As [mutable default arguments are discouraged](https://florimond.dev/blog/articles/2018/08/python-mutable-defaults-are-the-source-of-all-evil/), I changed the default argument to None and handle case appropriately by initializing an empty list.