### PR TITLE
Remove Test Directory from Setup.py MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ include MANIFEST.in
 include requirements.txt
 
 prune docs/_build
+prune fastparquet/test


### PR DESCRIPTION
Fixes issue in https://github.com/dask/fastparquet/issues/516

There is about 80mb of test files  in `fastparquet/test` that are included in the distribution or wheel file that are not needed. I've been deleting this folder before I push to aws lambda and experienced no issue.

I've used this command to test the build
`python setup.py sdist bdist_wheel`


