### PR TITLE
Adds support for decimal.Decimal type

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -205,6 +205,24 @@ def test_nulls_roundtrip(tempdir):
         assert (df[col] == data[col])[~data[col].isnull()].all()
         assert (data[col].isnull() == df[col].isnull()).all()
 
+def test_decimal_roundtrip(tempdir):
+    import decimal
+    def decimal_convert(x):
+        return decimal.Decimal(x)
+
+    fname = os.path.join(tempdir, 'decitemp.parq')
+    data = pd.DataFrame({'f64': np.arange(10000000, 10001000, dtype=np.float64) / 100000,
+                         'f16': np.arange(1000, dtype=np.float16) /10000
+                        })
+    data['f64']=data['f64'].apply(decimal_convert)
+    data['f16']=data['f16'].apply(decimal_convert)
+    writer.write(fname, data)
+
+    r = ParquetFile(fname)
+    df = r.to_pandas()
+    for col in r.columns:
+        assert (data[col] == df[col]).all()
+
 
 def test_make_definitions_with_nulls():
     for _ in range(10):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -28,6 +28,7 @@ from .util import (default_open, default_mkdirs,
                    check_column_names, metadata_from_many, created_by,
                    get_column_metadata)
 from .speedups import array_encode_utf8, pack_byte_array
+from decimal import Decimal
 
 MARKER = b'PAR1'
 NaT = np.timedelta64(None).tobytes()  # require numpy version >= 1.7
@@ -121,9 +122,12 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
         elif object_encoding == 'float':
             type, converted_type, width = (parquet_thrift.Type.DOUBLE, None,
                                            64)
+        elif object_encoding == 'decimal':
+            type, converted_type, width = (parquet_thrift.Type.DOUBLE, None,
+                                           64)
         else:
             raise ValueError('Object encoding (%s) not one of '
-                             'infer|utf8|bytes|json|bson|bool|int|int32|float' %
+                             'infer|utf8|bytes|json|bson|bool|int|int32|float|decimal' %
                              object_encoding)
         if fixed_text:
             width = fixed_text
@@ -173,6 +177,8 @@ def convert(data, se):
         try:
             if converted_type == parquet_thrift.ConvertedType.UTF8:
                 out = array_encode_utf8(data)
+            elif converted_type == parquet_thrift.ConvertedType.DECIMAL:
+                out = data.values.astype(np.float64, copy=False)
             elif converted_type is None:
                 if type in revmap:
                     out = data.values.astype(revmap[type], copy=False)
@@ -227,6 +233,8 @@ def infer_object_encoding(data):
         return 'json'
     elif all(isinstance(i, bool) for i in head):
         return 'bool'
+    elif all(isinstance(i, Decimal) for i in head):
+        return 'decimal'
     elif all(isinstance(i, integer_types) for i in head):
         return 'int'
     elif all(isinstance(i, float) or isinstance(i, np.floating)


### PR DESCRIPTION
This PR adds simple support for the decimal.Decimal type in fastparquet.
Even though there is a Decimal type in parquet, it it much more complicated to work with, and this solves the issue by converting it into a float type.

I might be able to work into the proper Decimal type support, but for now, this at least makes so fastparquet does not break when a Decimal type is supplied.

This was briefly discussed in issue #458, but it does not solve the original issue. It does, however, solve the issue for the Decimal type.