### PR TITLE
Add support to Write nullable pandas types (Int*|UInt*|boolean|string)

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -503,8 +503,8 @@ class ParquetFile(object):
                             for name, f in self.schema.root.children.items()
                             if getattr(f, 'isflat', False) is False)
         for i, (col, dt) in enumerate(dtype.copy().items()):
-            if dt.kind in ['i', 'b']:
-                # int/bool columns that may have nulls become float columns
+            if dt.kind in ['i', 'b', 'u']:
+                # uint/int/bool columns that may have nulls become float columns
                 num_nulls = 0
                 for rg in self.row_groups:
                     chunk = rg.columns[i]

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -217,7 +217,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
         my_nan = -1
         do_convert = False
     else:
-        if assign.dtype.kind in ['f', 'i']:
+        if assign.dtype.kind in ['f', 'i', 'u']:
             my_nan = np.nan
         elif assign.dtype.kind in ["M", 'm']:
             # GH#489 use a NaT representation compatible with ExtensionArray
@@ -263,7 +263,6 @@ def read_col(column, schema_helper, infile, use_cat=False,
             row_idx = 1 + encoding._assemble_objects(assign, defi, rep, val, dic, d,
                                              null, null_val, max_defi, row_idx)
         elif defi is not None:
-            max_defi = schema_helper.max_definition_level(cmd.path_in_schema)
             part = assign[num:num+len(defi)]
             part[defi != max_defi] = my_nan
             if d and not use_cat:

--- a/fastparquet/test/test_pd_optional_types.py
+++ b/fastparquet/test/test_pd_optional_types.py
@@ -1,0 +1,96 @@
+import os
+import pytest
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+import fastparquet as fp
+from fastparquet.test.util import tempdir
+from fastparquet import write, parquet_thrift
+from fastparquet.parquet_thrift.parquet import ttypes as tt
+import numpy.random as random
+
+
+EXPECTED_SERIES_INT8 = pd.Series(random.uniform(low=-128, high=127,size=100)).round()
+EXPECTED_SERIES_INT16 = pd.Series(random.uniform(low=-32768, high=32767,size=100)).round()
+EXPECTED_SERIES_INT32 = pd.Series(random.uniform(low=-2147483648, high=2147483647,size=100)).round()
+EXPECTED_SERIES_INT64 = pd.Series(random.uniform(low=-9223372036854775808, high=9223372036854775807,size=100)).round()
+EXPECTED_SERIES_UINT8 = pd.Series(random.uniform(low=0, high=255,size=100)).round()
+EXPECTED_SERIES_UINT16 = pd.Series(random.uniform(low=0, high=65535,size=100)).round()
+EXPECTED_SERIES_UINT32 = pd.Series(random.uniform(low=0, high=4294967295,size=100)).round()
+EXPECTED_SERIES_UINT64 = pd.Series(random.uniform(low=0, high=18446744073709551615,size=100)).round()
+EXPECTED_SERIES_BOOL = pd.Series(random.choice([False, True], 100))
+EXPECTED_SERIES_STRING = pd.Series(random.choice([
+    'You', 'are', 'my', 'fire', 
+    'The', 'one', 'desire', 
+    'Believe', 'when', 'I', 'say', 
+    'I', 'want', 'it', 'that', 'way'
+    ], 100))
+
+
+EXPECTED_SERIES_INT8.loc[20:30] = np.nan
+EXPECTED_SERIES_INT16.loc[20:30] = np.nan
+EXPECTED_SERIES_INT32.loc[20:30] = np.nan
+EXPECTED_SERIES_INT64.loc[20:30] = np.nan
+EXPECTED_SERIES_UINT8.loc[20:30] = np.nan
+EXPECTED_SERIES_UINT16.loc[20:30] = np.nan
+EXPECTED_SERIES_UINT32.loc[20:30] = np.nan
+EXPECTED_SERIES_UINT64.loc[20:30] = np.nan
+EXPECTED_SERIES_BOOL.loc[20:30] = np.nan
+EXPECTED_SERIES_STRING.loc[20:30] = np.nan
+
+
+TEST = pd.DataFrame({
+    'int8': EXPECTED_SERIES_INT8.astype('Int8'),
+    'int16': EXPECTED_SERIES_INT16.astype('Int16'),
+    'int32': EXPECTED_SERIES_INT32.astype('Int32'),
+    'int64': EXPECTED_SERIES_INT64.astype('Int64'),
+    'uint8': EXPECTED_SERIES_UINT8.astype('UInt8'),
+    'uint16': EXPECTED_SERIES_UINT16.astype('UInt16'),
+    'uint32': EXPECTED_SERIES_UINT32.astype('UInt32'),
+    'uint64': EXPECTED_SERIES_UINT64.astype('UInt64'),
+    'bool': EXPECTED_SERIES_BOOL.astype('boolean'),
+    'string': EXPECTED_SERIES_STRING.astype('string')
+})
+
+
+EXPECTED = pd.DataFrame({
+    'int8': EXPECTED_SERIES_INT8.astype('float16'),
+    'int16': EXPECTED_SERIES_INT16.astype('float32'),
+    'int32': EXPECTED_SERIES_INT32.astype('float64'),
+    'int64': EXPECTED_SERIES_INT64.astype('float64'),
+    'uint8': EXPECTED_SERIES_UINT8.astype('float16'),
+    'uint16': EXPECTED_SERIES_UINT16.astype('float32'),
+    'uint32': EXPECTED_SERIES_UINT32.astype('float64'),
+    'uint64': EXPECTED_SERIES_UINT64.astype('float64'),
+    'bool': EXPECTED_SERIES_BOOL.astype('float16'),
+    'string': EXPECTED_SERIES_STRING
+})
+
+
+EXPECTED_PARQUET_TYPES = {
+    'int8': 'INT32',
+    'int16': 'INT32',
+    'int32': 'INT32',
+    'int64': 'INT64',
+    'uint8': 'INT32',
+    'uint16': 'INT32',
+    'uint32': 'INT32',
+    'uint64': 'INT64',
+    'bool': 'BOOLEAN',
+    'string': 'BYTE_ARRAY'
+}
+
+@pytest.mark.parametrize('comp', (None,'snappy', 'gzip'))
+@pytest.mark.parametrize('scheme', ('simple', 'hive'))
+def test_write_nullable_columns(tempdir, scheme, comp):
+    fname = os.path.join(tempdir, 'test_write_nullable_columns.parquet')
+    write(fname, TEST, file_scheme=scheme, compression=comp)
+    pf = fp.ParquetFile(fname)
+    df = pf.to_pandas()
+    pq_types = {
+        se.name: tt.Type._VALUES_TO_NAMES[se.type]
+        for se in pf.schema.schema_elements
+        if se.type is not None
+    }
+    assert_frame_equal(EXPECTED, df)
+    assert pq_types == EXPECTED_PARQUET_TYPES

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -9,6 +9,7 @@ import warnings
 import numba
 import numpy as np
 import pandas as pd
+from pandas.core.arrays.masked import BaseMaskedDtype
 from six import integer_types
 
 from fastparquet.util import join_path, PANDAS_VERSION
@@ -35,6 +36,15 @@ NaT = np.timedelta64(None).tobytes()  # require numpy version >= 1.7
 nat = np.datetime64('NaT').view('int64')
 
 typemap = {  # primitive type, converted type, bit width
+    'boolean': (parquet_thrift.Type.BOOLEAN, None, 1),
+    'Int32': (parquet_thrift.Type.INT32, None, 32),
+    'Int64': (parquet_thrift.Type.INT64, None, 64),
+    'Int8': (parquet_thrift.Type.INT32, parquet_thrift.ConvertedType.INT_8, 8),
+    'Int16': (parquet_thrift.Type.INT32, parquet_thrift.ConvertedType.INT_16, 16),
+    'UInt8': (parquet_thrift.Type.INT32, parquet_thrift.ConvertedType.UINT_8, 8),
+    'UInt16': (parquet_thrift.Type.INT32, parquet_thrift.ConvertedType.UINT_16, 16),
+    'UInt32': (parquet_thrift.Type.INT32, parquet_thrift.ConvertedType.UINT_32, 32),
+    'UInt64': (parquet_thrift.Type.INT64, parquet_thrift.ConvertedType.UINT_64, 64),
     'bool': (parquet_thrift.Type.BOOLEAN, None, 1),
     'int32': (parquet_thrift.Type.INT32, None, 32),
     'int64': (parquet_thrift.Type.INT64, None, 64),
@@ -54,6 +64,17 @@ revmap = {parquet_thrift.Type.INT32: np.int32,
           parquet_thrift.Type.FLOAT: np.float32,
           parquet_thrift.Type.DOUBLE: np.float64}
 
+pdoptional_to_numpy_typemap = {
+    pd.Int8Dtype(): np.int8,
+    pd.Int16Dtype(): np.int16,
+    pd.Int32Dtype(): np.int32,
+    pd.Int64Dtype(): np.int64,
+    pd.UInt8Dtype(): np.uint8,
+    pd.UInt16Dtype(): np.uint16,
+    pd.UInt32Dtype(): np.uint32,
+    pd.UInt64Dtype(): np.uint64,
+    pd.BooleanDtype(): np.bool
+}
 
 def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
     """ Get appropriate typecodes for column dtype
@@ -148,6 +169,19 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
     elif dtype.kind == "m":
         type, converted_type, width = (parquet_thrift.Type.INT64,
                                        parquet_thrift.ConvertedType.TIME_MICROS, None)
+    elif str(dtype) == 'string': 
+        if object_encoding == 'infer':
+            object_encoding = infer_object_encoding(data)
+        
+        if object_encoding == 'utf8':
+            type, converted_type, width = (parquet_thrift.Type.BYTE_ARRAY,
+                                           parquet_thrift.ConvertedType.UTF8,
+                                           None)
+        elif object_encoding in ['bytes', None]:
+            type, converted_type, width = (parquet_thrift.Type.BYTE_ARRAY, None,
+                                           None)
+        else:
+            raise ValueError('Object Encoding (%s) not one of infer|utf8|bytes' % object_encoding)
     else:
         raise ValueError("Don't know how to convert data type: %s" % dtype)
     se = parquet_thrift.SchemaElement(
@@ -201,6 +235,21 @@ def convert(data, se):
             raise ValueError('Error converting column "%s" to bytes using '
                              'encoding %s. Original error: '
                              '%s' % (data.name, ct, e))
+    elif str(dtype) == "string":
+        try:
+            if converted_type == parquet_thrift.ConvertedType.UTF8:
+                out = array_encode_utf8(data)
+            elif converted_type is None:
+                out = data.values
+            if type == parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY:
+                out = out.astype('S%i' % se.type_length)
+        except Exception as e:
+            ct = parquet_thrift.ConvertedType._VALUES_TO_NAMES[
+                converted_type] if converted_type is not None else None
+            raise ValueError('Error converting column "%s" to bytes using '
+                             'encoding %s. Original error: '
+                             '%s' % (data.name, ct, e))
+
     elif converted_type == parquet_thrift.ConvertedType.TIMESTAMP_MICROS:
         out = np.empty(len(data), 'int64')
         time_shift(data.values.view('int64'), out)
@@ -445,11 +494,14 @@ def write_column(f, data, selement, compression=None):
     if has_nulls:
         if is_categorical_dtype(data.dtype):
             num_nulls = (data.cat.codes == -1).sum()
-        elif data.dtype.kind in ['i', 'b']:
-            num_nulls = 0
         else:
             num_nulls = len(data) - data.count()
         definition_data, data = make_definitions(data, num_nulls == 0)
+        # make_definitions returns `data` with all nulls dropped
+        # the null-stripped `data` can be converted from Optional Types to
+        # their numpy counterparts
+        if isinstance(data.dtype, BaseMaskedDtype):
+            data = data.astype(pdoptional_to_numpy_typemap[data.dtype])
         if data.dtype.kind == "O" and not is_categorical_dtype(data.dtype):
             try:
                 if selement.type == parquet_thrift.Type.INT64:

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -752,7 +752,7 @@ def make_metadata(data, has_nulls=True, ignore_columns=None, fixed_text=None,
                                       created_by=created_by,
                                       row_groups=[],
                                       key_value_metadata=[meta])
-
+    
     object_encoding = object_encoding or {}
     for column in data.columns:
         if column in ignore_columns:
@@ -940,7 +940,6 @@ def write(filename, data, row_group_offsets=50000000,
     fmd = make_metadata(data, has_nulls=has_nulls, ignore_columns=ignore,
                         fixed_text=fixed_text, object_encoding=object_encoding,
                         times=times, index_cols=index_cols)
-
     if file_scheme == 'simple':
         write_simple(filename, data, fmd, row_group_offsets,
                      compression, open_with, has_nulls, append)
@@ -979,7 +978,6 @@ def write(filename, data, row_group_offsets=50000000,
                     chunk.file_path = part
 
                 fmd.row_groups.append(rg)
-
         fmd.num_rows = sum(rg.num_rows for rg in fmd.row_groups)
         write_common_metadata(fn, fmd, open_with, no_row_groups=False)
         write_common_metadata(join_path(filename, '_common_metadata'), fmd,
@@ -1017,10 +1015,12 @@ def partition_on_columns(data, columns, root_path, partname, fmd,
     if not remaining:
         raise ValueError("Cannot include all columns in partition_on")
     rgs = []
-    for key, group in zip(sorted(gb.indices), sorted(gb)):
-        if group[1].empty:
+    for key, group in sorted(gb):
+        if group.empty:
+            print(f'group is empty for key: {key}')
+            print(group)
             continue
-        df = group[1][remaining]
+        df = group[remaining]
         if not isinstance(key, tuple):
             key = (key,)
         if with_field:

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1017,8 +1017,6 @@ def partition_on_columns(data, columns, root_path, partname, fmd,
     rgs = []
     for key, group in sorted(gb):
         if group.empty:
-            print(f'group is empty for key: {key}')
-            print(group)
             continue
         df = group[remaining]
         if not isinstance(key, tuple):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=0.19
+pandas>=1.0.0
 numba>=0.28
 numpy>=1.11
 packaging


### PR DESCRIPTION
Following the discussion on [PR-483](https://github.com/dask/fastparquet/pull/483)

>As per @TomAugspurger 's comment, perhaps we should split this into two PRs: one that copes with those extension types at write time, if we come across them, and another one (to be merged only later) that creates new extension types on reading for all relevant "optional" columns.

I have added support to write pandas nullable types. The behaviour of reading columns having null values is unchanged, i.e. `boolean` & `integer` columns with `null` values get upcast to the appropriate sized `float`, `string` columns with `null` values will get read as `object`. All existing code will continue to work as-is


```
import pandas as pd
import fastparquet as fp

df = pd.DataFrame({
  'a': pd.Series([1, 2, pd.NA], dtype='Int32'),
  'b': pd.Series([1, 2, 3], dtype='UInt32'),
  'c': pd.Series([True, False, pd.NA], dtype='boolean'),
  'd': pd.Series(['hello', 'world', pd.NA], dtype='string')
})
fp.write('test.pq', df, compression='snappy')
out = fp.ParquetFile('test.pq')
outdf = out.to_pandas()
outdf
# prints:
         a  b    c      d
    0  1.0  1  1.0  hello
    1  2.0  2  0.0  world
    2  NaN  3  NaN   None

print(outdf.dtypes)
# prints:
    a    float64
    b     uint32
    c    float16
    d     object
    dtype: object

print(out.schema)
# prints:
    - schema: 
    | - a: INT32, OPTIONAL
    | - b: INT32, UINT_32, OPTIONAL
    | - c: BOOLEAN, OPTIONAL
      - d: BYTE_ARRAY, UTF8, OPTIONAL
```


Inferring of optional types on read was omitted on purpose. But if needed, the numpy types can be converted to their fancy optional counterparts like below:


```
outdf.convert_dtypes({
  'a': 'Int32',
  'b': 'UInt32',
  'c': 'boolean',
  'd': 'string'
})
```

This PR will solve the issue [ValueError: Don't know how to convert data type: Int64](https://github.com/dask/fastparquet/issues/465)

It will also allow using fastparquet to generate Loading Files in ETL processes where the files' target is a database. Postgres & Redshift will refuse to load from a parquet file if a column is declared as an integer in the database but stored as a float in the parquet file.

While working on this PR, I also encountered & resolved a bug where unsigned integer columns in a parquet file with some null values would not be converted properly when using `out.to_pandas()`. To explore this bug, please generate a test output (i.e. run the code snipped above) using the branch `haleemur:feat/write-optional-types` and then attempt reading the test output using the master branch. 