### PR TITLE
remove note about needing LLVM 4.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Requirements
 
 Required:
 
-- numba (requires `LLVM 4.0.x`_)
+- numba
 - numpy
 - pandas
 - cython


### PR DESCRIPTION
The comment was largely outdated, Numba currently runs on LLVM 10 (except aarch64 which is stuck on LLVM 9). I think it will be best to not specify any LLVM version dependencies in the README at all.