### PR TITLE
store/use partition column metadata for categorical parsing

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -266,7 +266,7 @@ class ParquetFile(object):
                                           grab_dict=True)
         return out
 
-    def filter_row_groups(self, filters):
+    def filter_row_groups(self, filters, partition_meta=None):
         """
         Select row groups using set of filters
 
@@ -381,7 +381,7 @@ class ParquetFile(object):
         -------
         Pandas data-frame
         """
-        rgs = self.filter_row_groups(filters)
+        rgs = self.filter_row_groups(filters, partition_meta=self.partition_meta)
         size = sum(rg.num_rows for rg in rgs)
         index = self._get_index(index)
         if columns is not None:

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -299,11 +299,11 @@ def read_col(column, schema_helper, infile, use_cat=False,
 
 def read_row_group_file(fn, rg, columns, categories, schema_helper, cats,
                         open=open, selfmade=False, index=None, assign=None,
-                        scheme='hive'):
+                        scheme='hive', partition_meta=None):
     with open(fn, mode='rb') as f:
         return read_row_group(f, rg, columns, categories, schema_helper, cats,
                               selfmade=selfmade, index=index, assign=assign,
-                              scheme=scheme)
+                              scheme=scheme, partition_meta=partition_meta)
 
 
 def read_row_group_arrays(file, rg, columns, categories, schema_helper, cats,
@@ -345,10 +345,11 @@ def read_row_group_arrays(file, rg, columns, categories, schema_helper, cats,
 
 def read_row_group(file, rg, columns, categories, schema_helper, cats,
                    selfmade=False, index=None, assign=None,
-                   scheme='hive'):
+                   scheme='hive', partition_meta=None):
     """
     Access row-group in a file and read some columns into a data-frame.
     """
+    partition_meta = partition_meta or {}
     if assign is None:
         raise RuntimeError('Going with pre-allocation!')
     read_row_group_arrays(file, rg, columns, categories, schema_helper,
@@ -361,5 +362,6 @@ def read_row_group(file, rg, columns, categories, schema_helper, cats,
         else:
             partitions = [('dir%i' % i, v) for (i, v) in enumerate(
                 rg.columns[0].file_path.split('/')[:-1])]
-        val = val_to_num([p[1] for p in partitions if p[0] == cat][0])
+        key, val = [p for p in partitions if p[0] == cat][0]
+        val = val_to_num(val, meta=partition_meta.get(key))
         assign[cat][:] = cats[cat].index(val)

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -292,6 +292,7 @@ def test_numerical_partition_name(tempdir):
     assert out[out.y1 == 'aa'].x.tolist() == [1, 5, 5]
     assert out[out.y1 == 'bb'].x.tolist() == [2]
 
+
 def test_floating_point_partition_name(tempdir):
     df = pd.DataFrame({'x': [1e99, 5e-10, 2e+2, -0.1], 'y1': ['aa', 'aa', 'bb', 'aa']})
     write(tempdir, df, file_scheme='hive', partition_on=['y1'])
@@ -300,7 +301,22 @@ def test_floating_point_partition_name(tempdir):
     assert out[out.y1 == 'aa'].x.tolist() == [1e99, 5e-10, -0.1]
     assert out[out.y1 == 'bb'].x.tolist() == [200.0]
 
+
 def test_datetime_partition_names(tempdir):
+    dates = pd.to_datetime(['2015-05-09', '2018-10-15', '2020-10-17', '2015-05-09'])
+    df = pd.DataFrame({
+        'date': dates,
+        'x': [1, 5, 2, 5]
+    })
+    write(tempdir, df, file_scheme='hive', partition_on=['date'])
+    pf = ParquetFile(tempdir)
+    out = pf.to_pandas()
+    assert set(out.date.tolist()) == set(dates.tolist())
+    assert out[out.date == '2015-05-09'].x.tolist() == [1, 5]
+    assert out[out.date == '2020-10-17'].x.tolist() == [2]
+
+
+def test_string_partition_names(tempdir):
     date_strings = ['2015-05-09', '2018-10-15', '2020-10-17', '2015-05-09']
     df = pd.DataFrame({
         'date': date_strings,
@@ -309,7 +325,7 @@ def test_datetime_partition_names(tempdir):
     write(tempdir, df, file_scheme='hive', partition_on=['date'])
     pf = ParquetFile(tempdir)
     out = pf.to_pandas()
-    assert set(out.date.tolist()) == set(pd.to_datetime(date_strings).tolist())
+    assert set(out.date.tolist()) == set(date_strings)
     assert out[out.date == '2015-05-09'].x.tolist() == [1, 5]
     assert out[out.date == '2020-10-17'].x.tolist() == [2]
 

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -387,8 +387,8 @@ def test_filter_dates(tempdir):
     assert set(out_1.date.tolist()) == expected_dates
 
     out_2 = pf.to_pandas(filters=[('date', '==', 'may 9 2015')])
-    assert out_2.x.tolist() == [1]
-    assert out_2.date.tolist() == pd.to_datetime(['2015-05-09']).tolist()
+    assert out_2.x.tolist() == []
+    assert out_2.date.tolist() == []
 
 
 def test_in_filter(tempdir):

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -330,17 +330,6 @@ def test_string_partition_names(tempdir):
     assert out[out.date == '2020-10-17'].x.tolist() == [2]
 
 
-@pytest.mark.parametrize('partitions', [['2017-05-09', 'may 9 2017'], ['0.7', '.7']])
-def test_datetime_partition_no_dupilcates(tempdir, partitions):
-    df = pd.DataFrame({
-        'partitions': partitions,
-        'x': [1, 2]
-    })
-    write(tempdir, df, file_scheme='hive', partition_on=['partitions'])
-    with pytest.raises(ValueError, match=r'Partition names map to the same value.*'):
-        ParquetFile(tempdir)
-
-
 @pytest.mark.parametrize('categories', [['2017-05-09', 'may 9 2017'], ['0.7', '.7']])
 def test_datetime_category_no_dupilcates(tempdir, categories):
     # The purpose of this test is to ensure that the changes made for the previous test
@@ -352,17 +341,6 @@ def test_datetime_category_no_dupilcates(tempdir, categories):
     fn = os.path.join(tempdir, 'foo.parquet')
     write(fn, df)
     assert ParquetFile(fn).to_pandas().categories.tolist() == categories
-
-
-@pytest.mark.parametrize('partitions', [['2017-01-05', '1421'], ['0.7', '10']])
-def test_mixed_partition_types_warning(tempdir, partitions):
-    df = pd.DataFrame({
-        'partitions': partitions,
-        'x': [1, 2]
-    })
-    write(tempdir, df, file_scheme='hive', partition_on=['partitions'])
-    with pytest.warns(UserWarning, match=r'Partition names coerce to values of different types.*'):
-        ParquetFile(tempdir)
 
 
 def test_filter_without_paths(tempdir):
@@ -395,10 +373,10 @@ def test_filter_special(tempdir):
 def test_filter_dates(tempdir):
     df = pd.DataFrame({
         'x': [1, 2, 3, 4, 5, 6, 7],
-        'date': [
+        'date': pd.to_datetime([
             '2015-05-09', '2017-05-15', '2017-05-14',
             '2017-05-13', '2015-05-10', '2015-05-11', '2017-05-12'
-        ]
+        ])
     })
     write(tempdir, df, file_scheme='hive', partition_on=['date'])
     pf = ParquetFile(tempdir)
@@ -408,7 +386,7 @@ def test_filter_dates(tempdir):
     expected_dates = set(pd.to_datetime(['2017-05-15', '2017-05-14', '2017-05-13', '2017-05-12']))
     assert set(out_1.date.tolist()) == expected_dates
 
-    out_2 = pf.to_pandas(filters=[('date', '==', pd.to_datetime('may 9 2015'))])
+    out_2 = pf.to_pandas(filters=[('date', '==', 'may 9 2015')])
     assert out_2.x.tolist() == [1]
     assert out_2.date.tolist() == pd.to_datetime(['2015-05-09']).tolist()
 

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -54,6 +54,10 @@ def default_open(f, mode='rb'):
 
 def val_from_meta(x, meta):
     try:
+        if meta['pandas_type'] == 'categorical':
+            return x
+        if meta['numpy_type'] == 'bool':
+            return x != 'False'
         return np.dtype(meta['numpy_type']).type(x)
     except ValueError:
         if meta['numpy_type'] == 'datetime64[ns]':

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -26,7 +26,7 @@ from . import encoding, api, __version__
 from .util import (default_open, default_mkdirs,
                    PY2, STR_TYPE,
                    check_column_names, metadata_from_many, created_by,
-                   get_column_metadata)
+                   get_column_metadata, path_string)
 from .speedups import array_encode_utf8, pack_byte_array
 from decimal import Decimal
 
@@ -656,11 +656,13 @@ def make_part_file(f, data, schema, compression=None, fmd=None):
 
 
 def make_metadata(data, has_nulls=True, ignore_columns=None, fixed_text=None,
-                  object_encoding=None, times='int64', index_cols=None):
+                  object_encoding=None, times='int64', index_cols=None, partition_cols=None):
     if ignore_columns is None:
         ignore_columns = []
     if index_cols is None:
         index_cols = []
+    if partition_cols is None:
+        partition_cols = []
     if not data.columns.is_unique:
         raise ValueError('Cannot create parquet dataset with duplicate'
                          ' column names (%s)' % data.columns)
@@ -680,6 +682,7 @@ def make_metadata(data, has_nulls=True, ignore_columns=None, fixed_text=None,
                        'step': step,
                        'kind': 'range'}]
     pandas_metadata = {'index_columns': index_cols,
+                       'partition_columns': [],
                        'columns': [],
                        'column_indexes': [{'name': data.columns.name,
                                            'field_name': data.columns.name,
@@ -702,6 +705,8 @@ def make_metadata(data, has_nulls=True, ignore_columns=None, fixed_text=None,
                                       key_value_metadata=[meta])
 
     object_encoding = object_encoding or {}
+    for column in partition_cols:
+        pandas_metadata['partition_columns'].append(get_column_metadata(data[column], column))
     for column in data.columns:
         if column in ignore_columns:
             continue
@@ -887,7 +892,7 @@ def write(filename, data, row_group_offsets=50000000,
     ignore = partition_on if file_scheme != 'simple' else []
     fmd = make_metadata(data, has_nulls=has_nulls, ignore_columns=ignore,
                         fixed_text=fixed_text, object_encoding=object_encoding,
-                        times=times, index_cols=index_cols)
+                        times=times, index_cols=index_cols, partition_cols=partition_on)
 
     if file_scheme == 'simple':
         write_simple(filename, data, fmd, row_group_offsets,
@@ -973,7 +978,7 @@ def partition_on_columns(data, columns, root_path, partname, fmd,
             key = (key,)
         if with_field:
             path = join_path(*(
-                "%s=%s" % (name, val)
+                "%s=%s" % (name, path_string(val))
                 for name, val in zip(columns, key)
             ))
         else:


### PR DESCRIPTION
Resolves #528 by storing partition column metadata to the pandas_metadata. On read it uses this when parsing categorical values.