### PR TITLE
Row grouping by date and update of existing parquet part file based on this grouping

### DIFF
--- a/fastparquet/test/test_rgp_by_date.py
+++ b/fastparquet/test/test_rgp_by_date.py
@@ -1,0 +1,144 @@
+"""
+   test_rgp_by_date.py
+   Tests for row grouping by date in parquet data writing.
+"""
+
+import os
+import pandas as pd
+
+from fastparquet import write, ParquetFile
+from fastparquet.util import previous_date_offset
+from fastparquet.test.util import tempdir
+
+def test_midnight_anchoring():
+    """Test correct anchoring for miscellaneous date offsets."""
+    ts = pd.Timestamp('2020/01/02 08:59')
+    on_offset = pd.Timestamp('2020/01/02 08:40')    # test 20 minutes offset
+    assert previous_date_offset(ts, '20T', True, True) == on_offset
+    on_offset = pd.Timestamp('2020/01/02 08:00')    # test 2 hours offset
+    assert previous_date_offset(ts, '2H', True, True) == on_offset
+    on_offset = pd.Timestamp('2020/01/02 00:00')    # test 1 day offset
+    assert previous_date_offset(ts, '1D', True, True) == on_offset
+    on_offset = pd.Timestamp('2020/01/01 00:00')    # test 1 month offset
+    assert previous_date_offset(ts, '1M', True, True) == on_offset
+
+def test_write_with_rgp_by_date_as_index(tempdir):
+    fn = os.path.join(tempdir, 'foo.parquet')
+    offset = '2H'
+
+    # Case 1 - Date data used for grouping is DataFrame index.    
+    # Step 1 - Writing of a 1st df and testing correct grouping.
+    # df1 is not sorted: it will be sorted before writing.
+    df1 = pd.DataFrame({'humidity': [0.3, 0.8, 0.9],
+                        'pressure': [1e5, 1.1e5, 0.95e5],
+                        'location': ['Paris', 'Paris', 'Milan']},
+                        index = [pd.Timestamp('2020/01/02 01:59:00'),
+                                 pd.Timestamp('2020/01/02 03:59:00'),
+                                 pd.Timestamp('2020/01/02 02:59:00')])
+    write(fn, df1, row_group_offsets=offset, file_scheme='hive')
+    pf = ParquetFile(fn)
+    expected_1_1 = pd.DataFrame({'index': [pd.Timestamp('2020/01/02 01:59:00')],
+                                 'humidity': [0.3],
+                                 'pressure': [1e5],
+                                 'location': ['Paris']})
+    expected_1_1.index.name = 'index'
+    recorded_1_1 = pf.read_row_group_file(pf.row_groups[0], pf.columns, pf.categories)
+    assert expected_1_1.equals(recorded_1_1)
+    expected_1_2 = pd.DataFrame({'index': [pd.Timestamp('2020/01/02 02:59:00'),
+                                           pd.Timestamp('2020/01/02 03:59:00')],
+                                 'humidity': [0.9, 0.8],
+                                 'pressure': [0.95e5, 1.1e5],
+                                 'location': ['Milan', 'Paris']})
+    expected_1_2.index.name = 'index'
+    recorded_1_2 = pf.read_row_group_file(pf.row_groups[1], pf.columns, pf.categories)
+    assert expected_1_2.equals(recorded_1_2)
+
+    # Step 2 - Updating with a 2nd df having overlapping data and duplicates
+    #          and testing correct row group insertion and removal of duplicates.
+    # df2 is not sorted: it will be sorted before writing.
+    df2 = pd.DataFrame({'humidity': [0.5, 0.3, 0.4, 0.8, 1.1],
+                        'pressure': [9e4, 1e5, 1.1e5, 1.1e5, 0.95e5],
+                        'location': ['Tokyo', 'Paris', 'Paris', 'Paris', 'Paris']},
+                        index = [pd.Timestamp('2020/01/01 01:59:00'),
+                                 pd.Timestamp('2020/01/02 01:58:00'),
+                                 pd.Timestamp('2020/01/02 01:59:00'),
+                                 pd.Timestamp('2020/01/02 00:38:00'),
+                                 pd.Timestamp('2020/01/03 02:59:00')])
+    write(fn, df2, row_group_offsets=offset, file_scheme='hive', append=True,
+          drop_duplicates_on = 'index')
+    pf = ParquetFile(fn)
+    expected_2_1 = pd.DataFrame({'index': [pd.Timestamp('2020/01/01 01:59:00')],
+                                 'humidity': [0.5],
+                                 'pressure': [9e4],
+                                 'location': ['Tokyo']})
+    expected_2_1.index.name = 'index'
+    recorded_2_1 = pf.read_row_group_file(pf.row_groups[0], pf.columns, pf.categories)
+    assert expected_2_1.equals(recorded_2_1) # test row group insert in 1st position
+    expected_2_2 = pd.DataFrame({'index': [pd.Timestamp('2020-01-02 00:38:00'),
+                                           pd.Timestamp('2020-01-02 01:58:00'),
+                                           pd.Timestamp('2020-01-02 01:59:00')],
+                                 'humidity': [0.8, 0.3, 0.4],
+                                 'pressure': [1.1e5, 1e5, 1.1e5],
+                                 'location': ['Paris','Paris','Paris']})
+    expected_2_2.index.name = 'index'
+    recorded_2_2 = pf.read_row_group_file(pf.row_groups[1], pf.columns, pf.categories)
+    assert expected_2_2.equals(recorded_2_2) # test drop duplicate according timestamp and keep last.
+
+def test_write_with_rgp_by_date_as_col(tempdir):
+    fn = os.path.join(tempdir, 'foo.parquet')
+    offset = '2H'
+
+    # Case 2 - Date data used for grouping is 'timestamp' column.    
+    # Step 1 - Writing of a 1st df and testing correct grouping.
+    # df1 is not sorted: it will be sorted before writing.
+    df1 = pd.DataFrame({'timestamp': [pd.Timestamp('2020/01/02 01:59:00'),
+                                      pd.Timestamp('2020/01/02 03:59:00'),
+                                      pd.Timestamp('2020/01/02 02:59:00')],
+                        'humidity': [0.3, 0.8, 0.9],
+                        'pressure': [1e5, 1.1e5, 0.95e5],
+                        'location': ['Paris', 'Paris', 'Milan']})
+    write(fn, df1, row_group_offsets=offset, file_scheme='hive',
+          date_col='timestamp', write_index=False)
+    pf = ParquetFile(fn)
+    expected_1_1 = pd.DataFrame({'timestamp': [pd.Timestamp('2020/01/02 01:59:00')],
+                                 'humidity': [0.3],
+                                 'pressure': [1e5],
+                                 'location': ['Paris']})
+    recorded_1_1 = pf.read_row_group_file(pf.row_groups[0], pf.columns, pf.categories)
+    assert expected_1_1.equals(recorded_1_1)
+    expected_1_2 = pd.DataFrame({'timestamp': [pd.Timestamp('2020/01/02 02:59:00'),
+                                               pd.Timestamp('2020/01/02 03:59:00')],
+                                 'humidity': [0.9, 0.8],
+                                 'pressure': [0.95e5, 1.1e5],
+                                 'location': ['Milan', 'Paris']})
+    recorded_1_2 = pf.read_row_group_file(pf.row_groups[1], pf.columns, pf.categories)
+    assert expected_1_2.equals(recorded_1_2)
+
+    # Step 2 - Updating with a 2nd df having overlapping data and duplicates
+    #          and testing correct row group insertion and removal of duplicates.
+    # df2 is not sorted: it will be sorted before writing.
+    df2 = pd.DataFrame({'timestamp': [pd.Timestamp('2020/01/01 01:59:00'),
+                                      pd.Timestamp('2020/01/02 01:58:00'),
+                                      pd.Timestamp('2020/01/02 01:59:00'),
+                                      pd.Timestamp('2020/01/02 00:38:00'),
+                                      pd.Timestamp('2020/01/03 02:59:00')],
+                        'humidity': [0.5, 0.3, 0.4, 0.8, 1.1],
+                        'pressure': [9e4, 1e5, 1.1e5, 1.1e5, 0.95e5],
+                        'location': ['Tokyo', 'Paris', 'Paris', 'Paris', 'Paris']})
+    write(fn, df2, row_group_offsets=offset, file_scheme='hive', append=True,
+          drop_duplicates_on = 'timestamp', date_col='timestamp', write_index=False)
+    pf = ParquetFile(fn)
+    expected_2_1 = pd.DataFrame({'timestamp': [pd.Timestamp('2020/01/01 01:59:00')],
+                                 'humidity': [0.5],
+                                 'pressure': [9e4],
+                                 'location': ['Tokyo']})
+    recorded_2_1 = pf.read_row_group_file(pf.row_groups[0], pf.columns, pf.categories)
+    assert expected_2_1.equals(recorded_2_1) # test row group insert in 1st position
+    expected_2_2 = pd.DataFrame({'timestamp': [pd.Timestamp('2020-01-02 00:38:00'),
+                                           pd.Timestamp('2020-01-02 01:58:00'),
+                                           pd.Timestamp('2020-01-02 01:59:00')],
+                                 'humidity': [0.8, 0.3, 0.4],
+                                 'pressure': [1.1e5, 1e5, 1.1e5],
+                                 'location': ['Paris','Paris','Paris']})
+    recorded_2_2 = pf.read_row_group_file(pf.row_groups[1], pf.columns, pf.categories)
+    assert expected_2_2.equals(recorded_2_2) # test drop duplicate according timestamp and keep last.

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -832,7 +832,7 @@ def write(filename: str, data: pd.DataFrame, row_group_offsets = 50000000,
         - If int, row-groups will be approximately this many rows, rounded down
         to make row groups about the same size; if a list, the explicit index
         values to start new row groups.
-        - If str, it has to map to a pd.DateOffset. it is then used to group
+        - If str, it has to map to a pd.DateOffset. It is then used to group
         rows every this offset. In this case, either a date time column has
         to be specified or the index to be a pd.DatetimeIndex.
         Provided date group offset is automatically anchored to midnight.
@@ -913,7 +913,7 @@ def write(filename: str, data: pd.DataFrame, row_group_offsets = 50000000,
     date_col: str (None)
         Name of the column to use for grouping by date in case of a date row
         grouping. If `None`, index is used.
-    drop_duplicates_on (str or list, None)
+    drop_duplicates_on: str, list of str or None (None)
         Parameter used in case of a date row grouping.
         Either `None`, or a str or list of str specifying names of the columns
         to be used to identify duplicates.
@@ -925,9 +925,9 @@ def write(filename: str, data: pd.DataFrame, row_group_offsets = 50000000,
         Dropping duplicates on column values without the date used for grouping
         is not within the scope of the 'append' mode.
         The main reason is that duplicates are only searched within the same
-        row group (partition), that is defined according the date. Would two
-        rows be identified as duplicates only by use of their column values,
-        they could be on two different partitions (not same dates).
+        row group, that is defined according the date. Two rows identified as
+        duplicates only by use of their column values, cannot be removed if
+        they are in two different row groups (if not same dates).
     object_encoding: str or {col: type}
         For object columns, this gives the data type, so that the values can
         be encoded to bytes. Possible values are bytes|utf8|json|bson|bool|int|int32|decimal,
@@ -1096,9 +1096,8 @@ column/index name as in {!s}.'.format(str(drop_duplicates_on),
                             existing = pf\
                     .read_row_group_file(rg = part_number_to_rgp[part_number],
                                          columns = pf.columns,
-                                         categories = None,
+                                         categories = pf.categories,
                                          index = False,
-                                         assign = None,
                                          partition_meta = pf.partition_meta)
                             # Concat
                             data_slice = pd.concat([existing, data_slice])\


### PR DESCRIPTION
Implementation of row grouping by date.
In case of appending, existing parquet part file with data overlapping the new data according dates get concatenating.

New or modified parameters of `write` function:
```
    row_group_offsets: int, list of ints, or str
        - If int, row-groups will be approximately this many rows, rounded down
        to make row groups about the same size; if a list, the explicit index
        values to start new row groups.
        - If str, it has to map to a pd.DateOffset. it is then used to group
        rows every this offset. In this case, either a date time column has
        to be specified or the index to be a pd.DatetimeIndex.
        Provided date group offset is automatically anchored to midnight.
        Because of this midnight anchoring,
          * if a set of hours/minutes/seconds , it has to divide 24 hours
            in complete hours/minutes/seconds, so that 2 consecutive days split
            the same way.
          * if counted in day, week, month or year, it has to be a single unit
            (because no anchoring is provided for these larger timeframes)
          Examples of valid values: '2H', 'D', 'W', 'M'
          Examples of invalid values: '5H', '2D', '2W'...
```
```
    date_col: str (None)
        Name of the column to use for grouping by date in case of a date row
        grouping. If `None`, index is used.
```
```
    drop_duplicates_on (str or list, None)
        Parameter used in case of a date row grouping.
        Either `None`, or a str or list of str specifying names of the columns
        to be used to identify duplicates.
          * if a str or list of str, date column (or index) for grouping is
            necessarily added to this list. It can be only the name of the
            column/index embedding the dates to restrict to this data.
          * if `None`, both date column (or index) for grouping and all columns
            are used to identify duplicates.
        Dropping duplicates on column values without the date used for grouping
        is not within the scope of the 'append' mode.
        The main reason is that duplicates are only searched within the same
        row group (partition), that is defined according the date. Would two
        rows be identified as duplicates only by use of their column values,
        they could be on two different partitions (not same dates).
```

Following script available in repo for draft implementation 'thoroughly' tests this feature.
https://github.com/yohplala/fastparquet_append/blob/main/tests_fastparquet.py

This implementation is version 1.

As indicated in ticket #542 , it has following limitations:
- date offset and column name containing date for row grouping are not recorded in metadata, which would be a plus. User will have to remind this data when making an update with new data.
- no compatibility with file_scheme=simple. When starting to think about it, I got the thought that there is no apparent point in using this update feature when file is simple. In this case, were we to update a row group, then the full file would get rewritten anyway.
- no compatibility with partition_on. There does be interest to have this compatibility though. So later on, once a 1st version is working, I think I will come back to this.
- date data used cannot be pd.PeriodIndex, because of a limitation in fastparquet, as raised in ticket #543 

I propose to work out some of these limitations later, if need arises.