### PR TITLE
Simple pickle and small metadata parse speedups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.pyo
 *.so
 *.dll
 fastparquet/speedups.c

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -594,6 +594,7 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
         return cats
 
     cats = OrderedDict()
+    paths = set(path.rsplit("/", 1)[0] for path in paths)
     s = ex_from_sep('/')
     seen = set()
     if file_scheme == 'hive':

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -602,6 +602,9 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
             for path in paths
             for k, v in s.findall(path)
         ):
+            if (key, val) in seen:
+                continue
+            seen.add((key, val))
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
     else:
         for i, val in (

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -611,7 +611,7 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
         for i, val in (
             (i, val)
             for path in paths
-            for i, val in enumerate(path.split('/')[:-1])
+            for i, val in enumerate(path.split('/'))
         ):
             if (i, val) in seen:
                 continue

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -594,9 +594,7 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
         return cats
 
     cats = OrderedDict()
-    raw_cats = OrderedDict()
     s = ex_from_sep('/')
-    paths = set(paths)
     if file_scheme == 'hive':
         for key, val in set(
             (k, v)
@@ -604,7 +602,6 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
             for k, v in s.findall(path)
         ):
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
-            raw_cats.setdefault(key, set()).add(val)
     else:
         for i, val in set(
             (i, val)
@@ -613,7 +610,6 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
         ):
             key = 'dir%i' % i
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
-            raw_cats.setdefault(key, set()).add(val)
 
     cats = OrderedDict([(key, list(v)) for key, v in cats.items()])
     return cats

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -595,19 +595,23 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
 
     cats = OrderedDict()
     s = ex_from_sep('/')
+    seen = set()
     if file_scheme == 'hive':
-        for key, val in set(
+        for key, val in (
             (k, v)
             for path in paths
             for k, v in s.findall(path)
         ):
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
     else:
-        for i, val in set(
+        for i, val in (
             (i, val)
             for path in paths
             for i, val in enumerate(path.split('/')[:-1])
         ):
+            if (i, val) in seen:
+                continue
+            seen.add((i, val))
             key = 'dir%i' % i
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
 

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -18,8 +18,7 @@ from .thrift_structures import parquet_thrift
 from . import core, schema, converted_types, encoding, dataframe
 from .util import (default_open, ParquetException, val_to_num,
                    ensure_bytes, check_column_names, metadata_from_many,
-                   ex_from_sep, get_file_scheme, groupby_types,
-                   unique_everseen)
+                   ex_from_sep, get_file_scheme, groupby_types)
 
 
 class ParquetFile(object):
@@ -540,6 +539,13 @@ class ParquetFile(object):
         self.dtypes = dtype
         return dtype
 
+    def __getstate__(self):
+        return {"fn": self.fn, "open": self.open, "sep": self.sep, "fmd": self.fmd}
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._set_attrs()
+
     def __str__(self):
         return "<Parquet File: %s>" % self.info
 
@@ -590,42 +596,24 @@ def paths_to_cats(paths, file_scheme, partition_meta=None):
     cats = OrderedDict()
     raw_cats = OrderedDict()
     s = ex_from_sep('/')
-    paths = unique_everseen(paths)
+    paths = set(paths)
     if file_scheme == 'hive':
-        partitions = unique_everseen(
+        for key, val in set(
             (k, v)
             for path in paths
             for k, v in s.findall(path)
-        )
-        for key, val in partitions:
+        ):
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
             raw_cats.setdefault(key, set()).add(val)
     else:
-        i_val = unique_everseen(
+        for i, val in set(
             (i, val)
             for path in paths
             for i, val in enumerate(path.split('/')[:-1])
-        )
-        for i, val in i_val:
+        ):
             key = 'dir%i' % i
             cats.setdefault(key, set()).add(val_to_num(val, partition_meta.get(key)))
             raw_cats.setdefault(key, set()).add(val)
-
-    for key, v in cats.items():
-        # Check that no partition names map to the same value after transformation by val_to_num
-        raw = raw_cats[key]
-        if len(v) != len(raw):
-            conflicts_by_value = OrderedDict()
-            for raw_val in raw_cats[key]:
-                conflicts_by_value.setdefault(val_to_num(raw_val), set()).add(raw_val)
-            conflicts = [c for k in conflicts_by_value.values() if len(k) > 1 for c in k]
-            raise ValueError("Partition names map to the same value: %s" % conflicts)
-        vals_by_type = groupby_types(v)
-
-        # Check that all partition names map to the same type after transformation by val_to_num
-        if len(vals_by_type) > 1:
-            examples = [x[0] for x in vals_by_type.values()]
-            warnings.warn("Partition names coerce to values of different types, e.g. %s" % examples)
 
     cats = OrderedDict([(key, list(v)) for key, v in cats.items()])
     return cats

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -159,6 +159,20 @@ def test_iter(tempdir):
         next(out)
 
 
+def test_pickle(tempdir):
+    import pickle
+    df = pd.DataFrame({'x': [1, 2, 3, 4],
+                       'y': [1.0, 2.0, 1.0, 2.0],
+                       'z': ['a', 'b', 'c', 'd']})
+    df.index.name = 'index'
+
+    fn = os.path.join(tempdir, 'foo.parquet')
+    write(fn, df, row_group_offsets=[0, 2], write_index=True)
+    pf = ParquetFile(fn)
+    pf2 = pickle.loads(pickle.dumps(pf))
+    assert pf.to_pandas().equals(pf2.to_pandas())
+
+
 def test_attributes(tempdir):
     df = pd.DataFrame({'x': [1, 2, 3, 4],
                        'y': [1.0, 2.0, 1.0, 2.0],


### PR DESCRIPTION
A bigger parse improvement, not yet made, would be to call val_to_num only if the type is known from the metadata (no guessing, which is error prone) or when filtering, to the type of user-supplied comparison value.
This is complicated by the partitioning column metadata being in terms of the original column names, but these get lost when reading drill-style paths (could get reapplied, of course).
