### PR TITLE
Overwrite

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -66,8 +66,8 @@ Further options that may be of interest are:
 
 - the compression algorithms (typically "snappy", for fast, but not too space-efficient), which can vary by column
 - the row-group splits to apply, which may lead to efficiencies on loading, if some row-groups can be skipped. Statistics (min/max) are calculated for each column in each row-group on the fly.
-- multi-file saving can be enabled with the ``file_scheme`` keyword: hive-style output is a directory with a single metadata file and several data-files.
-- complementing ``file_scheme='hive'``, use of ``partition_on`` spread data in different directories. In this situation, ``append`` can be set to one value among ``False|True|'overwrite'``. With this latter mode, new data written in an existing directory replaces the existing content. 
+- multi-file saving can be enabled with the ``file_scheme="hive"|"drill"``: directory-tree-partitioned output with a single metadata file and several data-files, one or more per leaf directory. The values used for partitioning are encoded into the paths of the data files.
+- append to existing data sets with ``append=True``, adding new row-groups. For the specific case of "hive"-partitioned data and one file per partition, ``append="overwrite"`` is also allowed, which replaces partitions of the data where new data are given, but leaves other existing partitions untouched.
 - options has_nulls, fixed_text and write_index affect efficiency see the `api docs <./api.html#fastparquet.write>`_.
 
 .. code-block:: python

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -67,6 +67,7 @@ Further options that may be of interest are:
 - the compression algorithms (typically "snappy", for fast, but not too space-efficient), which can vary by column
 - the row-group splits to apply, which may lead to efficiencies on loading, if some row-groups can be skipped. Statistics (min/max) are calculated for each column in each row-group on the fly.
 - multi-file saving can be enabled with the ``file_scheme`` keyword: hive-style output is a directory with a single metadata file and several data-files.
+- complementing ``file_scheme='hive'``, use of ``partition_on`` spread data in different directories. In this situation, ``append`` can be set to one value among ``False|True|'overwrite'``. With this latter mode, new data written in an existing directory replaces the existing content. 
 - options has_nulls, fixed_text and write_index affect efficiency see the `api docs <./api.html#fastparquet.write>`_.
 
 .. code-block:: python

--- a/fastparquet/test/test_overwrite.py
+++ b/fastparquet/test/test_overwrite.py
@@ -1,6 +1,6 @@
 """
-   test_rgp_by_date.py
-   Tests for row grouping by date in parquet data writing.
+   test_overwrite.py
+   Tests for overwriting parquet files.
 """
 
 import pandas as pd

--- a/fastparquet/test/test_overwrite.py
+++ b/fastparquet/test/test_overwrite.py
@@ -1,0 +1,45 @@
+"""
+   test_rgp_by_date.py
+   Tests for row grouping by date in parquet data writing.
+"""
+
+import pandas as pd
+
+from fastparquet import write, ParquetFile
+from fastparquet.test.util import tempdir
+
+
+def test_write_with_rgp_by_date_as_index(tempdir):
+
+    # Step 1 - Writing of a 1st df, with `row_group_offsets=0`,
+    # `file_scheme=hive` and `partition_on=['location', 'color`].
+    df1 = pd.DataFrame({'humidity': [0.3, 0.8, 0.9],
+                        'pressure': [1e5, 1.1e5, 0.95e5],
+                        'location': ['Paris', 'Paris', 'Milan'],
+                        'color': ['red', 'black', 'blue']})
+    write(tempdir, df1, row_group_offsets=0, file_scheme='hive',
+          partition_on=['location', 'color'])
+
+    # Step 2 - Overwriting with a 2nd df having overlapping data, in
+    # 'overwrite' mode:
+    # `row_group_offsets=0`, `file_scheme=hive`,
+    # `partition_on=['location', 'color`] and `append=True`.
+    df2 = pd.DataFrame({'humidity': [0.5, 0.3, 0.4, 0.8, 1.1],
+                        'pressure': [9e4, 1e5, 1.1e5, 1.1e5, 0.95e5],
+                        'location': ['Milan', 'Paris', 'Paris', 'Paris', 'Paris'],
+                        'color': ['red', 'black', 'black', 'green', 'green' ]})
+
+    write(tempdir, df2, row_group_offsets=0, file_scheme='hive', append=True,
+          partition_on=['location', 'color'])
+
+    expected = pd.DataFrame({'humidity': [0.9, 0.5, 0.3, 0.4, 0.8, 1.1, 0.3],
+                             'pressure': [9.5e4, 9e4, 1e5, 1.1e5, 1.1e5, 9.5e4, 1e5],
+                             'location': ['Milan', 'Milan', 'Paris', 'Paris', 'Paris', 'Paris', 'Paris'],
+                             'color': ['blue', 'red', 'black', 'black', 'green', 'green', 'red']})\
+                           .astype({'location': 'category', 'color': 'category'})
+    recorded = ParquetFile(tempdir).to_pandas()
+    # df1 is 3 rows, df2 is 5 rows. Because of overlapping data with keys
+    # 'location' = 'Paris' & 'color' = 'black' (1 row in df2, 2 rows in df2)
+    # resulting df contains for this combination values of df2 and not that of
+    # df1. Total resulting number of rows is 7.
+    assert expected.equals(recorded)

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -894,8 +894,10 @@ def write(filename, data, row_group_offsets=50000000,
         - If False, construct data-set from scratch; if True, add new row-group(s)
           to existing data-set. In the latter case, the data-set must exist,
           and the schema must match the input data.
-        - If 'overwrite', existing data can be replaced. To enable this, these other
-          parameters have to be set to specific values, or will raise ValueError:
+        - If 'overwrite', existing partitions will be replaced in-place, where
+          the given data has any rows within a given partition. To enable this,
+          these other parameters have to be set to specific values, or will
+          raise ValueError:
            * ``row_group_offsets=0``
            * ``file_scheme='hive'``
            * ``partition_on`` has to be used, set to at least a column name

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -925,13 +925,15 @@ def write(filename, data, row_group_offsets=50000000,
     """
     if str(has_nulls) == 'infer':
         has_nulls = None
-
+    # Variable 'exist_rgps' is initialized if 'write' is used in 'overwrite' mode.
+    exist_rgps = None
+    rgo_zero_flag = False
     if isinstance(row_group_offsets, int):
         if not row_group_offsets:
             # To keep track row_group_offsets was initially 0.
             rgo_zero_flag = True
             row_group_offsets = [0]
-        else:
+        else: 
             l = len(data)
             nparts = max((l - 1) // row_group_offsets + 1, 1)
             chunksize = max(min((l - 1) // nparts + 1, l), 1)
@@ -953,8 +955,6 @@ def write(filename, data, row_group_offsets=50000000,
                         fixed_text=fixed_text, object_encoding=object_encoding,
                         times=times, index_cols=index_cols,
                         partition_cols=partition_on)
-    # Variable 'exist_rgps' is initialized if 'write' is used in 'overwrite' mode.
-    exist_rgps = None
 
     if file_scheme == 'simple':
         write_simple(filename, data, fmd, row_group_offsets,

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -895,7 +895,7 @@ def write(filename, data, row_group_offsets=50000000,
           to existing data-set. In the latter case, the data-set must exist,
           and the schema must match the input data.
         - If 'overwrite', existing data can be replaced. To enable this, these other
-          parameters have to be set to specific values:
+          parameters have to be set to specific values, or will raise ValueError:
            * ``row_group_offsets=0``
            * ``file_scheme='hive'``
            * ``partition_on`` has to be used, set to at least a column name

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -927,8 +927,7 @@ def write(filename, data, row_group_offsets=50000000,
         has_nulls = None
     if isinstance(row_group_offsets, int):
         l = len(data)
-        nparts = max((l - 1) // row_group_offsets + 1, 1) if row_group_offsets\
-                                                          else 1
+        nparts = max((l - 1) // row_group_offsets + 1, 1) if row_group_offsets else 1
         chunksize = max(min((l - 1) // nparts + 1, l), 1)
         row_group_offsets = list(range(0, l, chunksize))
     if (write_index or write_index is None
@@ -948,8 +947,7 @@ def write(filename, data, row_group_offsets=50000000,
                         fixed_text=fixed_text, object_encoding=object_encoding,
                         times=times, index_cols=index_cols,
                         partition_cols=partition_on)
-    # Variable 'exist_rgps' is initialized if 'write' is used in 'overwrite'
-    # mode.
+    # Variable 'exist_rgps' is initialized if 'write' is used in 'overwrite' mode.
     exist_rgps = None
 
     if file_scheme == 'simple':
@@ -1007,8 +1005,8 @@ def write(filename, data, row_group_offsets=50000000,
                             # in the 1st place.
                             row_group_index = bisect(exist_rgps, part_val)
                             fmd.row_groups.insert(row_group_index, new_rgps[part_val])
-                            # Keep part number list clean for next 'replace' or
-                            # 'insert' cases.
+                            # Keep 'exist_rgps' list clean for next 'replace'
+                            # or 'insert' cases.
                             exist_rgps.insert(row_group_index, part_val)
                     
             else:

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1004,10 +1004,7 @@ part files, while overwrite of data is requested. This case is not handled.')
                     # Get 'new' combinations of values from columns listed in
                     # 'partition_on',along with corresponding row groups.
                     new_rgps = {'_'.join(rg.columns[0].file_path.split('/')[:-1]): rg \
-                              for rg in rgs}
-#R
-                    print(new_rgps.keys())
-                    
+                              for rg in rgs}                    
                     for part_val in new_rgps:
                         if part_val in exist_rgps:
                             # Replace existing row group metadata with new ones.

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -974,7 +974,11 @@ def write(filename, data, row_group_offsets=50000000,
                 # (to have partition values).
                 exist_rgps = ['_'.join(rg.columns[0].file_path.split('/')[:-1])
                               for rg in fmd.row_groups]
-                row_group_offsets = [0]
+                if len(exist_rgps) > len(set(exist_rgps)):
+                    # Some groups are in the same folder (partition). This case
+                    # is not handled.
+                    raise ValueError('Some partition folders contain several \
+part files, while overwrite of data is requested. This case is not handled.')
                 i_offset = 0
             else:
                 i_offset = find_max_part(fmd.row_groups)                
@@ -1001,6 +1005,9 @@ def write(filename, data, row_group_offsets=50000000,
                     # 'partition_on',along with corresponding row groups.
                     new_rgps = {'_'.join(rg.columns[0].file_path.split('/')[:-1]): rg \
                               for rg in rgs}
+#R
+                    print(new_rgps.keys())
+                    
                     for part_val in new_rgps:
                         if part_val in exist_rgps:
                             # Replace existing row group metadata with new ones.


### PR DESCRIPTION
Hi @martindurant 

I am opening this new PR in replacement of PR #546.
Following your proposal, I setup most (all actually?) modifications of a DataFrame in case of data overlap outside fastparquet `write` function. 
More precisely, definition of the metric to sort and identify overlap (by date), retrieval of overlapped data, concatenation with new one, and removal of duplicates and sorting steps are all removed.

I have only kept an 'overwrite' mode.

The use case is as follow:
- data is already stored, with `partition_on` listing one or several columns AND `row_group_offsets=0`.
- when overwrite is used, for the same combination of values from columns listed in `partition_on`, if a file is already existing, it is overwritten
- its metadata is also replaced.

I did not create any new parameter for this `overwrite`. Instead I used a specific combination of existing parameters... but likely hard to be found by anyone :) so worth reading the docstring to be aware of it :)
This combination makes use of a combination that was actually raising a bug (when `row_group_offsets = 0`).

This function is triggered with use of `write` function and a specific combination of parameters.
row_group_offsets = 0
file_scheme = 'hive'
partition_on initialized
append = True

A test case is provided in the PR.
Thanks in advance for your feedback about it.
Have a good evening,
Bests,

PS:
 - I spot a bug that I did not solve. I am opening a ticket. ('drill' cannot be used with 'append').
 - I am wondering as it is my case. Do you think we can save any CPU by providing the `fp.ParquetFile`as a parameter to `write`in case of `append` to initialize `pf` in place of the line [942](https://github.com/dask/fastparquet/blob/d9cb86d33cedb7cdda1893e569c48ced75e419d0/fastparquet/writer.py#L942)
 In my case, because I will have managed concatenation, I will have it, so I can provide it through a parameter when calling `fastparquet.write()`. Do you think it does worth it?