### PR TITLE
Taking into account 'write_index = False' when index is a RangeIndex in 'write'.

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -928,3 +928,11 @@ def test_pandas_metadata_inference():
     assert df.index.tolist() == [0, 1]
     assert df.index.name is None
 
+
+def test_write_index_false(tempdir):
+    fn = os.path.join(tempdir, 'test.parquet')
+    df = pd.DataFrame(0, columns=['a'], index=range(1,3))
+    write(fn, df, write_index=False)
+    rec_df = ParquetFile(fn).to_pandas()
+    assert rec_df.index[0] == 0
+    

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -931,7 +931,7 @@ def write(filename, data, row_group_offsets=50000000,
         cols = set(data)
         data = data.reset_index()
         index_cols = [c for c in data if c not in cols]
-    elif isinstance(data.index, pd.RangeIndex):
+    elif write_index is None and isinstance(data.index, pd.RangeIndex):
         # write_index=None, range to metadata
         index_cols = data.index
     else:  # write_index=False


### PR DESCRIPTION
Fixes #581.