### PR TITLE
'filters' do not raise exception if columns filter is not existing

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -494,6 +494,16 @@ def test_in_filter_rowgroups(tempdir):
     assert row_groups[1].x.tolist() == [8, 9]
 
 
+def test_unexisting_filter_cols(tempdir):
+    fn = os.path.join(tempdir, 'test.parq') 
+    df = pd.DataFrame({'a': range(5), 'b': [1, 1, 2, 2, 2]})
+    write(fn, df, file_scheme='hive', partition_on='b')
+    pf = ParquetFile(fn)
+    with pytest.raises(ValueError, match="{'c'}.$"):
+        rec_df = ParquetFile(fn).to_pandas(filters=[(('a', '>=', 0),
+                                                     ('c', '==', 0),)])
+    
+
 def test_index_not_in_columns(tempdir):
     df = pd.DataFrame({'a': ['x', 'y', 'z'], 'b': [4, 5, 6]}).set_index('a')
     write(tempdir, df, file_scheme='hive')
@@ -525,6 +535,7 @@ def test_no_index_name(tempdir):
     out = pf.to_pandas()
     assert out.index.name is None
     assert out.index.tolist() == [0, 1, 2]
+
 
 def test_input_column_list_not_mutated(tempdir):
     df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
@@ -822,6 +833,7 @@ def test_path_containing_metadata_df():
     df = p.to_pandas()
     assert list(p.columns) == ['a', 'b', 'c', '__index_level_0__']
     assert len(df) == 0
+
 
 def test_empty_df():
     p = ParquetFile(os.path.join(TEST_DATA, "empty.parquet"))


### PR DESCRIPTION
Hi

Well, here is a proposal to solve #584 .

I have yet to add a testcase as well I guess ;).
Please, is it first possible to have a feedback on this proposal?
I have added a check before the filtering operation.

I had a look in the functions that apply the filters:
`filter_out_cats`
`filter_out_stats`

As I understand, they both operate the same way by iterating over existing columns (respectively cats), and if they identify filters that apply to the current column (resp. cats), then a check is made to see if it has to be filtered out or not.
So, no surprise that if a filter is defined with an unexisting column, it has no effect.

Maybe another proposal could have been to check independently cats in `filter_out_cats` and cols in `filter_out_stats`.
Lines of code to achieve the check would then be duplicated between both functions.
So I retained to have them directly in the header function `filter_row_groups`

Thanks in advance for your feedback.
Bests,




 