### PR TITLE
fix date column ( 0.6.1 ) 

### DIFF
--- a/fastparquet/compression.py
+++ b/fastparquet/compression.py
@@ -1,5 +1,6 @@
 
 import cramjam
+import numpy as np
 from .thrift_structures import parquet_thrift
 
 # TODO: use stream/direct-to-buffer conversions instead of memcopy
@@ -97,6 +98,13 @@ def decompress_data(data, uncompressed_size, algorithm='gzip'):
     if isinstance(algorithm, int):
         algorithm = rev_map[algorithm]
     if algorithm.upper() not in decompressions:
-        raise RuntimeError("Decompression '%s' not available.  Options: %s" %
-                (algorithm.upper(), sorted(decompressions)))
+        raise RuntimeError(
+            "Decompression '%s' not available.  Options: %s" %
+            (algorithm.upper(), sorted(decompressions))
+        )
+    if algorithm.upper() in decom_into:
+        # ensures writable buffer from cramjam
+        x = np.empty(uncompressed_size, dtype='uint8')
+        decom_into[algorithm.upper()](data, x)
+        return x
     return decompressions[algorithm.upper()](data, uncompressed_size)

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -131,7 +131,7 @@ def convert(data, se, timestamp96=True):
                 for i in range(len(data))
             ])
     elif ctype == parquet_thrift.ConvertedType.DATE:
-        data *= DAYS_TO_MILLIS
+        data = data * DAYS_TO_MILLIS
         return data.view('datetime64[ns]')
     elif ctype == parquet_thrift.ConvertedType.TIME_MILLIS:
         out = data.astype('int64', copy=False)

--- a/fastparquet/test/test_converted_types.py
+++ b/fastparquet/test/test_converted_types.py
@@ -32,7 +32,9 @@ def test_date():
         converted_type=pt.ConvertedType.DATE,
     )
     days = (datetime.date(2004, 11, 3) - datetime.date(1970, 1, 1)).days
-    assert (convert(pd.Series([days]), schema)[0] ==
+    data = pd.Series([days]).to_numpy()
+    data.flags.writeable = False
+    assert (convert(data, schema)[0] ==
             pd.to_datetime([datetime.date(2004, 11, 3)]))
 
 


### PR DESCRIPTION
When trying to read a parquet file with a DATE column I started to get:
```
ValueError: assignment destination is read-only
```

Seems like the NumPy object is immutable and ```*=``` will not work.
In the previous test setup, the object would be writeable by default, tried to reflect it by making the series a NumPy immutable object as when reading from a parquet file.  