### PR TITLE
Pandas nullable types

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -592,25 +592,9 @@ class ParquetFile(object):
                             for name, f in self.schema.root.children.items()
                             if getattr(f, 'isflat', False) is False)
         for i, (col, dt) in enumerate(dtype.copy().items()):
-            if dt.kind in ['i', 'b', 'u']:
-                # uint/int/bool columns that may have nulls become float columns
-                num_nulls = 0
-                for rg in self.row_groups:
-                    st = rg.columns[i].meta_data.statistics
-                    if st is None:
-                        num_nulls = True
-                        break
-                    if st.null_count:
-                        num_nulls = True
-                        break
-                if num_nulls:
-                    if dtype[col].itemsize == 1:
-                        dtype[col] = np.dtype('f2')
-                    elif dtype[col].itemsize == 2:
-                        dtype[col] = np.dtype('f4')
-                    else:
-                        dtype[col] = np.dtype('f8')
-            elif dt.kind == "M":
+            # int and bool columns produce masked pandas types, no need to
+            # promote types here
+            if dt.kind == "M":
                 if tz is not None and tz.get(col, False):
                     z = dataframe.tz_to_dt_tz(tz[col])
                     dtype[col] = pd.Series([], dtype='M8[ns]').dt.tz_localize(z).dtype

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -630,13 +630,16 @@ def _pre_allocate(size, columns, categories, index, cs, dt, tz=None):
     if isinstance(categories, dict):
         cats.update(categories)
 
-    def get_type(name):
+    def get_type(name, index=False):
         if name in categories:
             return 'category'
-        return dt.get(name, None)
+        t = dt[name]
+        if index and isinstance(t, pd.core.arrays.masked.BaseMaskedDtype):
+            return "int64"
+        return t
 
     dtypes = [get_type(c) for c in cols]
-    index_types = [get_type(i) for i in index]
+    index_types = [get_type(i, index=True) for i in index]
     cols.extend(cs)
     dtypes.extend(['category'] * len(cs))
     df, views = dataframe.empty(dtypes, size, cols=cols, index_names=index,

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -127,6 +127,8 @@ class ParquetFile(object):
                         self._parse_header(f, verify)
                     fn = fn2
                 else:
+                    # TODO: get details from fs here, rather than do suffix cat in
+                    #  metadata_from_many
                     if "*" in fn:
                         allfiles = fs.glob(fn)
                     else:

--- a/fastparquet/benchmarks/columns.py
+++ b/fastparquet/benchmarks/columns.py
@@ -46,7 +46,7 @@ def time_column():
             if col == 'x':
                 assert (df.x.astype('timedelta64[us]') == df.x.astype('timedelta64[us]')).all()
             else:
-                assert pf.to_pandas().equals(df)  # warm-up
+                assert (pf.to_pandas() == df).values.all()  # warm-up
 
             with measure('%s: read, no nulls' % d.dtypes[col], result):
                 pf.to_pandas()
@@ -58,7 +58,7 @@ def time_column():
             if col == 'x':
                 assert (df.x.astype('timedelta64[us]') == df.x.astype('timedelta64[us]')).all()
             else:
-                assert pf.to_pandas().equals(df)  # warm-up
+                assert (pf.to_pandas() == df).values.all()  # warm-up
 
             with measure('%s: read, no nulls, has_null=True' % d.dtypes[col], result):
                 pf.to_pandas()
@@ -78,7 +78,7 @@ def time_column():
             if col == 'x':
                 assert (df.x.astype('timedelta64[us]') == df.x.astype('timedelta64[us]')).all()
             else:
-                assert pf.to_pandas().equals(df)  # warm-up
+                assert (pf.to_pandas() == df).values.all()  # warm-up
 
             with measure('%s: read, with null, has_null=True' % d.dtypes[col], result):
                 pf.to_pandas()
@@ -90,7 +90,7 @@ def time_column():
             if col == 'x':
                 assert (df.x.astype('timedelta64[us]') == df.x.astype('timedelta64[us]')).all()
             else:
-                assert pf.to_pandas().equals(df)  # warm-up
+                assert (pf.to_pandas() == df).values.all()  # warm-up
 
             with measure('%s: read, with null, has_null=False' % d.dtypes[col], result):
                 pf.to_pandas()

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -68,6 +68,17 @@ nullable = {
     np.dtype('int64'): pd.Int64Dtype(),
     np.dtype('bool'): pd.BooleanDtype()
 }
+pandas_nullable = {
+    "Int8": pd.Int8Dtype(),
+    "Int16": pd.Int16Dtype(),
+    "Int32": pd.Int32Dtype(),
+    "Int64": pd.Int64Dtype(),
+    "UInt8": pd.UInt8Dtype(),
+    "UInt16": pd.UInt16Dtype(),
+    "UInt32": pd.UInt32Dtype(),
+    "UInt64": pd.UInt64Dtype(),
+    "boolean": pd.BooleanDtype()
+}
 
 
 def typemap(se, md=None):
@@ -76,9 +87,9 @@ def typemap(se, md=None):
     md = md.get(se.name, {})
     if md and ("Int" in md["numpy_type"] or md["numpy_type"] == "boolean"):
         # arrow has numpy and pandas types swapped
-        return pd.core.dtypes.base.registry.find(md["numpy_type"])
+        return pandas_nullable[md["numpy_type"]]
     if md and ("Int" in md["pandas_type"] or md["pandas_type"] == "boolean"):
-        return pd.core.dtypes.base.registry.find(md["pandas_type"])
+        return pandas_nullable[md["pandas_type"]]
     if se.converted_type is None:
         if se.type in simple:
             return simple[se.type]

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -36,34 +36,49 @@ DAYS_TO_MILLIS = 86400000000000
 """Number of millis in a day. Used to convert a Date to a date"""
 nat = np.datetime64('NaT').view('int64')
 
-simple = {parquet_thrift.Type.INT32: pd.Int32Dtype(),
-          parquet_thrift.Type.INT64: pd.Int64Dtype(),
-          parquet_thrift.Type.FLOAT: np.dtype('float32'),
-          parquet_thrift.Type.DOUBLE: np.dtype('float64'),
-          parquet_thrift.Type.BOOLEAN: pd.BooleanDtype(),
-          parquet_thrift.Type.INT96: np.dtype('S12'),
-          parquet_thrift.Type.BYTE_ARRAY: np.dtype("O"),
-          parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY: np.dtype("O")}
-complex = {parquet_thrift.ConvertedType.UTF8: np.dtype("O"),
-           parquet_thrift.ConvertedType.DECIMAL: np.dtype('float64'),
-           parquet_thrift.ConvertedType.UINT_8: pd.UInt8Dtype(),
-           parquet_thrift.ConvertedType.UINT_16: pd.UInt16Dtype(),
-           parquet_thrift.ConvertedType.UINT_32: pd.UInt32Dtype(),
-           parquet_thrift.ConvertedType.UINT_64: pd.UInt64Dtype(),
-           parquet_thrift.ConvertedType.INT_8: pd.Int8Dtype(),
-           parquet_thrift.ConvertedType.INT_16: pd.Int16Dtype(),
-           parquet_thrift.ConvertedType.INT_32: pd.Int32Dtype(),
-           parquet_thrift.ConvertedType.INT_64: pd.Int64Dtype(),
-           parquet_thrift.ConvertedType.TIME_MILLIS: np.dtype('<m8[ns]'),
-           parquet_thrift.ConvertedType.DATE: np.dtype('<M8[ns]'),
-           parquet_thrift.ConvertedType.TIMESTAMP_MILLIS: np.dtype('<M8[ns]'),
-           parquet_thrift.ConvertedType.TIME_MICROS: np.dtype('<m8[ns]'),
-           parquet_thrift.ConvertedType.TIMESTAMP_MICROS: np.dtype('<M8[ns]')
-           }
+simple = {
+    parquet_thrift.Type.INT32: np.dtype('int32'),
+    parquet_thrift.Type.INT64: np.dtype('int64'),
+    parquet_thrift.Type.FLOAT: np.dtype('float32'),
+    parquet_thrift.Type.DOUBLE: np.dtype('float64'),
+    parquet_thrift.Type.BOOLEAN: np.dtype('bool'),
+    parquet_thrift.Type.INT96: np.dtype('S12'),
+    parquet_thrift.Type.BYTE_ARRAY: np.dtype("O"),
+    parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY: np.dtype("O")
+}
+complex = {
+    parquet_thrift.ConvertedType.UTF8: np.dtype("O"),
+    parquet_thrift.ConvertedType.DECIMAL: np.dtype('float64'),
+    parquet_thrift.ConvertedType.UINT_8: pd.UInt8Dtype(),
+    parquet_thrift.ConvertedType.UINT_16: pd.UInt16Dtype(),
+    parquet_thrift.ConvertedType.UINT_32: np.dtype('uint32'),
+    parquet_thrift.ConvertedType.UINT_64: np.dtype('uint64'),
+    parquet_thrift.ConvertedType.INT_8: pd.Int8Dtype(),
+    parquet_thrift.ConvertedType.INT_16: pd.Int16Dtype(),
+    parquet_thrift.ConvertedType.INT_32: np.dtype('int32'),
+    parquet_thrift.ConvertedType.INT_64: np.dtype('int64'),
+    parquet_thrift.ConvertedType.TIME_MILLIS: np.dtype('<m8[ns]'),
+    parquet_thrift.ConvertedType.DATE: np.dtype('<M8[ns]'),
+    parquet_thrift.ConvertedType.TIMESTAMP_MILLIS: np.dtype('<M8[ns]'),
+    parquet_thrift.ConvertedType.TIME_MICROS: np.dtype('<m8[ns]'),
+    parquet_thrift.ConvertedType.TIMESTAMP_MICROS: np.dtype('<M8[ns]')
+}
+nullable = {
+    np.dtype('int32'): pd.Int32Dtype(),
+    np.dtype('int64'): pd.Int64Dtype(),
+    np.dtype('bool'): pd.BooleanDtype()
+}
 
 
-def typemap(se):
+def typemap(se, md=None):
     """Get the final dtype - no actual conversion"""
+    md = md or {}
+    md = md.get(se.name, {})
+    if md and ("Int" in md["numpy_type"] or md["numpy_type"] == "boolean"):
+        # arrow has numpy and pandas types swapped
+        return pd.core.dtypes.base.registry.find(md["numpy_type"])
+    if md and ("Int" in md["pandas_type"] or md["pandas_type"] == "boolean"):
+        return pd.core.dtypes.base.registry.find(md["pandas_type"])
     if se.converted_type is None:
         if se.type in simple:
             return simple[se.type]

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -9,6 +9,7 @@ but they're not necessarily the most performant.
 import json
 import logging
 import numpy as np
+import pandas as pd
 
 from .thrift_structures import parquet_thrift
 from .cencoding import time_shift
@@ -35,24 +36,24 @@ DAYS_TO_MILLIS = 86400000000000
 """Number of millis in a day. Used to convert a Date to a date"""
 nat = np.datetime64('NaT').view('int64')
 
-simple = {parquet_thrift.Type.INT32: np.dtype('int32'),
-          parquet_thrift.Type.INT64: np.dtype('int64'),
+simple = {parquet_thrift.Type.INT32: pd.Int32Dtype(),
+          parquet_thrift.Type.INT64: pd.Int64Dtype(),
           parquet_thrift.Type.FLOAT: np.dtype('float32'),
           parquet_thrift.Type.DOUBLE: np.dtype('float64'),
-          parquet_thrift.Type.BOOLEAN: np.dtype('bool'),
+          parquet_thrift.Type.BOOLEAN: pd.BooleanDtype(),
           parquet_thrift.Type.INT96: np.dtype('S12'),
           parquet_thrift.Type.BYTE_ARRAY: np.dtype("O"),
           parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY: np.dtype("O")}
 complex = {parquet_thrift.ConvertedType.UTF8: np.dtype("O"),
            parquet_thrift.ConvertedType.DECIMAL: np.dtype('float64'),
-           parquet_thrift.ConvertedType.UINT_8: np.dtype('uint8'),
-           parquet_thrift.ConvertedType.UINT_16: np.dtype('uint16'),
-           parquet_thrift.ConvertedType.UINT_32: np.dtype('uint32'),
-           parquet_thrift.ConvertedType.UINT_64: np.dtype('uint64'),
-           parquet_thrift.ConvertedType.INT_8: np.dtype('int8'),
-           parquet_thrift.ConvertedType.INT_16: np.dtype('int16'),
-           parquet_thrift.ConvertedType.INT_32: np.dtype('int32'),
-           parquet_thrift.ConvertedType.INT_64: np.dtype('int64'),
+           parquet_thrift.ConvertedType.UINT_8: pd.UInt8Dtype(),
+           parquet_thrift.ConvertedType.UINT_16: pd.UInt16Dtype(),
+           parquet_thrift.ConvertedType.UINT_32: pd.UInt32Dtype(),
+           parquet_thrift.ConvertedType.UINT_64: pd.UInt64Dtype(),
+           parquet_thrift.ConvertedType.INT_8: pd.Int8Dtype(),
+           parquet_thrift.ConvertedType.INT_16: pd.Int16Dtype(),
+           parquet_thrift.ConvertedType.INT_32: pd.Int32Dtype(),
+           parquet_thrift.ConvertedType.INT_64: pd.Int64Dtype(),
            parquet_thrift.ConvertedType.TIME_MILLIS: np.dtype('<m8[ns]'),
            parquet_thrift.ConvertedType.DATE: np.dtype('<M8[ns]'),
            parquet_thrift.ConvertedType.TIMESTAMP_MILLIS: np.dtype('<M8[ns]'),

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from distutils.version import LooseVersion
 import numpy as np
 from pandas import (
-    Categorical, DataFrame, Series,
+    arrays, Categorical, DataFrame, Series,
     CategoricalIndex, RangeIndex, Index, MultiIndex,
     __version__ as pdver, DatetimeIndex
 )
@@ -88,8 +88,15 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
     df = OrderedDict()
     for t, col in zip(types, cols):
         if str(t) == 'category':
-            df[str(col)] = Categorical([], categories=cat(col),
-                                                 fastpath=True)
+            df[str(col)] = Categorical([], categories=cat(col), fastpath=True)
+        elif str(t)[0] in {"I", "U"} or str(t) == "boolean":
+            # pandas masked types
+            arr_type = t.construct_array_type()
+            df[str(col)] = arr_type(
+                values=np.empty(0, dtype=t.numpy_dtype),
+                mask=np.empty(0, dtype=np.bool_),
+                copy=False
+            )
         else:
             if hasattr(t, 'base'):
                 # funky pandas not-dtype
@@ -162,8 +169,6 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             views[col] = d
             views[col+'-catdef'] = x
 
-    axes = [df._data.axes[0], index]
-
     # Patch our blocks with desired-length arrays.  Kids: don't try this at home.
     mgr = df._data
     for block in mgr.blocks:
@@ -186,9 +191,20 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 # e.g. DatetimeLikeBlock backed by DatetimeArray/TimedeltaArray
                 if bvalues.dtype.kind == "m":
                     values = np.zeros(shape=shape, dtype="m8[ns]")
+                    values = type(bvalues)._from_sequence(values, copy=False)
                 elif bvalues.dtype.kind == "M":
                     values = np.zeros(shape=shape, dtype="M8[ns]")
-                values = type(bvalues)._from_sequence(values, copy=False)
+                    values = type(bvalues)._from_sequence(values, copy=False)
+                elif str(bvalues.dtype)[0] in {"I", "U"} or str(bvalues.dtype) == "boolean":
+                    arr_type = bvalues.dtype.construct_array_type()
+                    values = arr_type(
+                        values=np.empty(size, dtype=bvalues.dtype.numpy_dtype),
+                        mask=np.zeros(size, dtype=np.bool_)
+                    )
+                else:
+                    import pdb
+                    pdb.set_trace()
+                    raise NotImplementedError
             else:
                 values = np.empty(shape=shape, dtype=bvalues.dtype)
 
@@ -210,6 +226,8 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 views[col+'-catdef'] = block.values
             elif getattr(block.dtype, 'tz', None):
                 views[col] = np.asarray(block.values, dtype='M8[ns]')
+            elif str(dtype)[0] in {"I", "U"} or str(dtype) == "boolean":
+                views[col] = block.values
             else:
                 views[col] = block.values[i]
 

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -130,7 +130,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
         else:
             if hasattr(t, 'base'):
                 # funky pandas not-dtype
-                t = t.base
+                 t = t.base
             d = np.empty(size, dtype=t)
             if d.dtype.kind == "M" and str(col) in timezones:
                 # 1) create the DatetimeIndex in UTC as no datetime conversion is needed and
@@ -213,7 +213,6 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
 
     mgr.axes[-1] = index
 
-    # create block manager
     # create views
     for block in df._data.blocks:
         dtype = block.dtype
@@ -226,7 +225,11 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 views[col] = block.values._codes
                 views[col+'-catdef'] = block.values
             elif getattr(block.dtype, 'tz', None):
-                views[col] = np.asarray(block.values, dtype='M8[ns]').squeeze()
+                arr = np.asarray(block.values, dtype='M8[ns]')
+                if len(arr.shape) > 1:
+                    # pandas >= 1.3 does this for some reason
+                    arr = arr.squeeze(axis=0)
+                views[col] = arr
             elif str(dtype)[0] in {"I", "U"} or str(dtype) == "boolean":
                 views[col] = block.values
             else:

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -226,7 +226,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 views[col] = block.values._codes
                 views[col+'-catdef'] = block.values
             elif getattr(block.dtype, 'tz', None):
-                views[col] = np.asarray(block.values, dtype='M8[ns]')
+                views[col] = np.asarray(block.values, dtype='M8[ns]').squeeze()
             elif str(dtype)[0] in {"I", "U"} or str(dtype) == "boolean":
                 views[col] = block.values
             else:

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -3,10 +3,11 @@ from collections import OrderedDict
 from distutils.version import LooseVersion
 import numpy as np
 from pandas import (
-    arrays, Categorical, DataFrame, Series,
+    Categorical, DataFrame, Series,
     CategoricalIndex, RangeIndex, Index, MultiIndex,
-    __version__ as pdver, DatetimeIndex
+    __version__ as pdver, DatetimeIndex, Int64Index
 )
+from pandas.core.arrays.masked import BaseMaskedDtype
 from pandas.api.types import is_categorical_dtype
 import warnings
 
@@ -89,7 +90,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
     for t, col in zip(types, cols):
         if str(t) == 'category':
             df[str(col)] = Categorical([], categories=cat(col), fastpath=True)
-        elif str(t)[0] in {"I", "U"} or str(t) == "boolean":
+        elif isinstance(t, BaseMaskedDtype):
             # pandas masked types
             arr_type = t.construct_array_type()
             df[str(col)] = arr_type(

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -166,9 +166,9 @@ def test_iter(tempdir):
     pf = ParquetFile(fn)
     out = iter(pf.iter_row_groups(index='index'))
     d1 = next(out)
-    pd.testing.assert_frame_equal(d1, df[:2])
+    pd.testing.assert_frame_equal(d1, df[:2], check_dtype=False, check_index_type=False)
     d2 = next(out)
-    pd.testing.assert_frame_equal(d2, df[2:])
+    pd.testing.assert_frame_equal(d2, df[2:], check_dtype=False, check_index_type=False)
     with pytest.raises(StopIteration):
         next(out)
 
@@ -267,7 +267,7 @@ def test_attributes(tempdir):
     assert join_path(fn) == pf.info['name']
     assert join_path(fn) in str(pf)
     for col in df:
-        assert pf.dtypes[col] == df.dtypes[col]
+        assert getattr(pf.dtypes[col], "numpy_dtype", pf.dtypes[col]) == df.dtypes[col]
 
 
 def test_open_standard(tempdir):
@@ -279,7 +279,7 @@ def test_open_standard(tempdir):
           open_with=open)
     pf = ParquetFile(fn, open_with=open)
     d2 = pf.to_pandas()
-    pd.testing.assert_frame_equal(d2, df)
+    pd.testing.assert_frame_equal(d2, df, check_dtype=False)
 
 
 def test_filelike(tempdir):
@@ -291,12 +291,12 @@ def test_filelike(tempdir):
     with open(fn, 'rb') as f:
         pf = ParquetFile(f, open_with=open)
         d2 = pf.to_pandas()
-        pd.testing.assert_frame_equal(d2, df)
+        pd.testing.assert_frame_equal(d2, df, check_dtype=False)
 
     b = io.BytesIO(open(fn, 'rb').read())
     pf = ParquetFile(b, open_with=open)
     d2 = pf.to_pandas()
-    pd.testing.assert_frame_equal(d2, df)
+    pd.testing.assert_frame_equal(d2, df, check_dtype=False)
 
 
 def test_cast_index(tempdir):
@@ -358,7 +358,7 @@ def test_read_multiple_no_metadata(tempdir):
     pf = ParquetFile(flist)
     assert len(pf.row_groups) == 2
     out = pf.to_pandas()
-    pd.testing.assert_frame_equal(out, df)
+    pd.testing.assert_frame_equal(out, df, check_dtype=False)
 
 
 def test_single_upper_directory(tempdir):
@@ -446,7 +446,7 @@ def test_filter_without_paths(tempdir):
 
     pf = ParquetFile(fn)
     out = pf.to_pandas(filters=[['x', '>', 3]])
-    pd.testing.assert_frame_equal(out, df)
+    pd.testing.assert_frame_equal(out, df, check_dtype=False)
     out = pf.to_pandas(filters=[['x', '>', 30]])
     assert len(out) == 0
 
@@ -758,7 +758,7 @@ def test_compression_zstd(tempdir):
 
     df2 = p.to_pandas()
 
-    pd.testing.assert_frame_equal(df, df2)
+    pd.testing.assert_frame_equal(df, df2, check_dtype=False)
 
 
 def test_compression_lz4(tempdir):
@@ -797,7 +797,7 @@ def test_compression_lz4(tempdir):
 
     df2 = p.to_pandas()
 
-    pd.testing.assert_frame_equal(df, df2)
+    pd.testing.assert_frame_equal(df, df2, check_dtype=False)
 
 
 def test_compression_snappy(tempdir):
@@ -833,7 +833,7 @@ def test_compression_snappy(tempdir):
 
     df2 = p.to_pandas()
 
-    pd.testing.assert_frame_equal(df, df2)
+    pd.testing.assert_frame_equal(df, df2, check_dtype=False)
 
 
 def test_int96_stats(tempdir):
@@ -910,8 +910,8 @@ def test_multi_cat(tempdir):
 
     pf = ParquetFile(fn)
     df1 = pf.to_pandas()
-    assert df1.equals(df)
-    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])
+    assert (df1.index.values == df.index.values).all()
+    assert (df1.loc[1, 'a'].values == df.loc[1, 'a'].values).all()
 
 
 def test_multi_cat_single(tempdir):
@@ -925,8 +925,8 @@ def test_multi_cat_single(tempdir):
     write(fn, df)
     pf = ParquetFile(fn)
     df1 = pf.to_pandas()
-    assert df1.equals(df)
-    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])
+    assert (df1.index.values == df.index.values).all()
+    assert (df1.loc[1, 'a'].values == df.loc[1, 'a'].values).all()
 
 
 def test_multi_cat_split(tempdir):
@@ -943,8 +943,8 @@ def test_multi_cat_split(tempdir):
 
     pf = ParquetFile(fn)
     df1 = pf.to_pandas()
-    assert df1.equals(df)
-    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])
+    assert (df1.index.values == df.index.values).all()
+    assert (df1.loc[1, 'a'].values == df.loc[1, 'a'].values).all()
 
 
 def test_multi(tempdir):
@@ -959,8 +959,8 @@ def test_multi(tempdir):
 
     pf = ParquetFile(fn)
     df1 = pf.to_pandas()
-    assert df1.equals(df)
-    assert df1.loc[1, 'a'].equals(df.loc[1, 'a'])
+    assert (df1.index.values == df.index.values).all()
+    assert (df1.loc[1, 'a'].values == df.loc[1, 'a'].values).all()
 
 
 def test_simple_nested():

--- a/fastparquet/test/test_aroundtrips.py
+++ b/fastparquet/test/test_aroundtrips.py
@@ -150,11 +150,11 @@ def test_empty_row_groups(tempdir, sql):
     pf = fastparquet.ParquetFile(files)  # don't necessarily have metadata
     assert len(files) > 1  # more than one worker was writing
     d = pf.to_pandas(index=False)
-    pd.testing.assert_frame_equal(d, d0)
+    assert d.to_dict() == d0.to_dict()
 
     # destroy empty files
     [os.unlink(f) for (f, s) in zip(files, sizes) if s < msize]
 
     # loads anyway, since empty row-groups are not touched
     d = pf.to_pandas()
-    pd.testing.assert_frame_equal(d, d0)
+    assert d.to_dict() == d0.to_dict()

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -551,8 +551,7 @@ def test_null_time(tempdir):
     assert sum(data['t'].isnull()) == sum(expected['t'].isnull())
 
 
-@pytest.mark.xfail(reason="to be rewritten")
-def test_auto_null(tempdir):
+def test_auto_null_object(tempdir):
     tmp = str(tempdir)
     df = pd.DataFrame({'a': [1, 2, 3, 0],
                        'aa': [1, 2, 3, None],
@@ -579,7 +578,7 @@ def test_auto_null(tempdir):
 
     tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False,
                           check_dtype=False)
-    tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['ff']].astype("boolean"), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
@@ -592,7 +591,7 @@ def test_auto_null(tempdir):
 
     tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False,
                           check_dtype=False)
-    tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['ff']].astype('boolean'), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
@@ -606,7 +605,7 @@ def test_auto_null(tempdir):
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
     df2 = pf.to_pandas()
     tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
-    tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['ff']].astype('boolean'), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 
@@ -620,7 +619,7 @@ def test_auto_null(tempdir):
             assert col.repetition_type == parquet_thrift.FieldRepetitionType.REQUIRED
     df2 = pf.to_pandas()
     tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
-    tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
+    tm.assert_frame_equal(df[['ff']].astype('boolean'), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
 

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -402,7 +402,7 @@ def test_write_compression_dict(tempdir, compression):
     r = ParquetFile(fn)
     df2 = r.to_pandas()
 
-    tm.assert_frame_equal(df, df2, check_categorical=False)
+    tm.assert_frame_equal(df, df2, check_categorical=False, check_dtype=False)
 
 
 def test_write_compression_schema(tempdir):
@@ -435,7 +435,7 @@ def test_index(tempdir):
     assert meta['index_columns'] == ['z']
     out = pf.to_pandas()
     assert out.index.name == 'z'
-    pd.testing.assert_frame_equal(df, out)
+    pd.testing.assert_frame_equal(df, out, check_dtype=False)
     out = pf.to_pandas(index=False)
     assert out.index.name is None
     assert (out.index == range(3)).all()
@@ -551,6 +551,7 @@ def test_null_time(tempdir):
     assert sum(data['t'].isnull()) == sum(expected['t'].isnull())
 
 
+@pytest.mark.xfail(reason="to be rewritten")
 def test_auto_null(tempdir):
     tmp = str(tempdir)
     df = pd.DataFrame({'a': [1, 2, 3, 0],
@@ -576,7 +577,8 @@ def test_auto_null(tempdir):
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     df2 = pf.to_pandas(categories=['e'])
 
-    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False,
+                          check_dtype=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
@@ -588,7 +590,8 @@ def test_auto_null(tempdir):
         assert col.repetition_type == parquet_thrift.FieldRepetitionType.OPTIONAL
     df2 = pf.to_pandas(categories=['e'])
 
-    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False)
+    tm.assert_frame_equal(df[test_cols], df2[test_cols], check_categorical=False,
+                          check_dtype=False)
     tm.assert_frame_equal(df[['ff']].astype('float16'), df2[['ff']])
     tm.assert_frame_equal(df[['bb']].astype('float64'), df2[['bb']])
     tm.assert_frame_equal(df[['aaa']].astype('int64'), df2[['aaa']])
@@ -634,7 +637,7 @@ def test_many_categories(tempdir, n):
     pf = ParquetFile(fn)
     out = pf.to_pandas(categories={'x': n})
 
-    tm.assert_frame_equal(df, out, check_categorical=False)
+    tm.assert_frame_equal(df, out, check_categorical=False, check_dtype=False)
 
     df.set_index('x', inplace=True)
     write(fn, df, has_nulls=False, write_index=True)
@@ -750,8 +753,8 @@ def test_append_simple(tempdir):
 
     pf = ParquetFile(fn)
     expected = pd.concat([df, df], ignore_index=True)
-    pd.testing.assert_frame_equal(pf.to_pandas(), expected,
-                                       check_categorical=False)
+    pd.testing.assert_frame_equal(
+        pf.to_pandas(), expected, check_categorical=False, check_dtype=False)
 
 
 @pytest.mark.parametrize('scheme', ('hive', 'simple'))
@@ -766,9 +769,8 @@ def test_append_empty(tempdir, scheme):
     write(fn, df, append=True, write_index=False, file_scheme=scheme)
 
     pf = ParquetFile(fn)
-    pd.testing.assert_frame_equal(pf.to_pandas(), df,
-                                       check_categorical=False)
-
+    pd.testing.assert_frame_equal(
+        pf.to_pandas(), df, check_categorical=False, check_dtype=False)
 
 
 @pytest.mark.parametrize('row_groups', ([0], [0, 2]))

--- a/fastparquet/test/test_pd_optional_types.py
+++ b/fastparquet/test/test_pd_optional_types.py
@@ -92,5 +92,5 @@ def test_write_nullable_columns(tempdir, scheme, comp):
         for se in pf.schema.schema_elements
         if se.type is not None
     }
-    assert_frame_equal(EXPECTED, df)
+    assert_frame_equal(EXPECTED, df, check_index_type=False, check_dtype=False)
     assert pq_types == EXPECTED_PARQUET_TYPES

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -256,7 +256,8 @@ def test_index(tempdir):
         fastparquet.write(tempdir, d2, file_scheme='hive', write_index=True)
         pf = fastparquet.ParquetFile(tempdir)
         out = pf.to_pandas(index=column, categories=['b'])
-        pd.testing.assert_frame_equal(out, d2, check_categorical=False)
+        pd.testing.assert_frame_equal(out, d2, check_categorical=False,
+                                      check_index_type=False, check_dtype=False)
 
 
 def test_skip_length():
@@ -314,8 +315,8 @@ def test_null_sizes(tempdir):
     df = pd.DataFrame({'a': [True, None], 'b': [3000, np.nan]}, dtype="O")
     fastparquet.write(tempdir, df, has_nulls=True, file_scheme='hive')
     pf = fastparquet.ParquetFile(tempdir)
-    assert pf.dtypes['a'] == 'float16'
-    assert pf.dtypes['b'] == 'float64'
+    assert pf.dtypes['a'] == 'boolean'
+    assert pf.dtypes['b'] == 'Int64'
 
 
 def test_multi_index(tempdir):

--- a/fastparquet/test/test_with_n.py
+++ b/fastparquet/test/test_with_n.py
@@ -112,10 +112,11 @@ def test_read_data():
 
 
 def test_to_pandas():
+    import pandas as pd
     fname = TEST_DATA+'/airlines_parquet/4345e5eef217aa1b-c8f16177f35fd983_1150363067_data.1.parq'
     pf = ParquetFile(fname)
     out = pf.to_pandas()
     assert len(out.columns) == 29
     # test for bad integer conversion
     assert (out.dep_time < 0).sum() == 0
-    assert out.dep_time.dtype == 'float64'
+    assert out.dep_time.dtype == pd.Int32Dtype()

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -275,6 +275,9 @@ def get_column_metadata(column, name):
     # https://github.com/apache/arrow/blob/master/python/pyarrow/pandas_compat.py
     inferred_dtype = infer_dtype(column)
     dtype = column.dtype
+    if str(dtype) == "bool":
+        # pandas accidentally calls this "boolean"
+        inferred_dtype = "bool"
 
     if is_categorical_dtype(dtype):
         extra_metadata = {
@@ -328,6 +331,10 @@ def get_column_metadata(column, name):
 def get_numpy_type(dtype):
     if is_categorical_dtype(dtype):
         return 'category'
+    elif "Int" in str(dtype):
+        return str(dtype).lower()
+    elif str(dtype) == "boolean":
+        return "bool"
     else:
         return str(dtype)
 


### PR DESCRIPTION
Will now create columns of nullable types always for (u)int and bools. No change for strings, StringDType gives no benefit.
