### PR TITLE
check schema before simple append, #626

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -818,6 +818,18 @@ def test_append_fail(tempdir):
     assert 'existing file scheme' in str(e.value)
 
 
+def test_append_fail_incompatible(tempdir):
+    fn = os.path.join(str(tempdir), 'test.parq')
+    df1 = pd.DataFrame({'a': [1, 2, 3, 0],
+                       'b': ['a', 'a', 'b', 'b']})
+    df2 = pd.DataFrame({'a': [1, 2, 3, 0]})
+    write(fn, df1, file_scheme='simple')
+    with pytest.raises(ValueError) as e:
+        write(fn, df2, file_scheme='simple', append=True)
+    assert 'schema is not compatible' in str(e.value)
+    pd.testing.assert_frame_equal(ParquetFile(fn).to_pandas(), df1)
+
+
 def test_append_w_partitioning(tempdir):
     fn = str(tempdir)
     df = pd.DataFrame({'a': np.random.choice([1, 2, 3], size=50),

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -737,6 +737,9 @@ def write_simple(fn, data, fmd, row_group_offsets, compression,
         if pf.file_scheme not in ['simple', 'empty']:
             raise ValueError('File scheme requested is simple, but '
                              'existing file scheme is not')
+        if sorted(pf.columns) != sorted(data.columns):
+            raise ValueError('File schema is not compatible with '
+                             'existing file schema.')
         fmd = pf.fmd
         mode = 'rb+'
     else:


### PR DESCRIPTION
This patch addresses issue #626. Without this patch, the append portion of the unit test will raise a KeyError on the missing column. The parquet file will be corrupt. Specifically it will fail to open with a TypeError because the root schema value is None.

I considered implementing this for hive here: https://github.com/dask/fastparquet/blob/main/fastparquet/writer.py#L921 . However when writing the test, I wrote one for hive and the issue did not reproduce with scheme set to 'hive'. @martindurant can you advise if you feel this is an issue for hive/drill as well?