### PR TITLE
Bump version to 0.6.4.dev0

### DIFF
--- a/fastparquet/__init__.py
+++ b/fastparquet/__init__.py
@@ -1,5 +1,5 @@
 """parquet - read parquet files."""
-__version__ = "0.6.3"
+__version__ = "0.6.4.dev0"
 
 from .thrift_structures import parquet_thrift
 from .core import read_thrift

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = open('requirements.txt').read().strip().split('\n')
 
 setup(
     name='fastparquet',
-    version='0.6.3',
+    version='0.6.4.dev0',
     description='Python support for Parquet file format',
     author='Martin Durant',
     author_email='mdurant@canaconda.com',


### PR DESCRIPTION
This will help improve version comparisons for projects which use the development version of `fastparquet` (e.g. in an upstream CI build)

```python
In [1]: from distutils.version import LooseVersion

In [2]: "0.6.4.dev0" <= LooseVersion("0.6.3")
Out[2]: False
```