### PR TITLE
Add support for old numpy versions (so that Fastparquet can be used with numpy 1.18.x, 1.19.x,...)

### DIFF
--- a/.github/workflows/test_wheel.yaml
+++ b/.github/workflows/test_wheel.yaml
@@ -1,0 +1,74 @@
+name: Test PyPi wheels
+
+on: [push, pull_request]
+
+
+jobs:
+  build:
+    # this job should be nearly identical to the 'build' job in wheel.yml
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, windows-2019]
+        architecture: ['x64']
+        linux_archs: ["native"]
+        numpy_version: ["numpy#latest", "numpy~=1.18.0", "numpy~=1.19.0", "numpy~=1.20.0", "numpy~=1.21.0"]
+        include:
+          # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
+          - os: windows-2019
+            skip: "*2*win* *win32 pp*"
+          - os: ubuntu-20.04
+            linux_archs: native
+            skip: "pp*"
+
+    name: Test wheel (${{ matrix.numpy_version }} + ${{ matrix.os }})
+    env:
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+      CIBW_BEFORE_ALL: "pip install numpy cython"
+      CIBW_SKIP: ${{ matrix.skip }}
+      CIBW_ARCHS_LINUX: ${{ matrix.linux_archs }}
+      CIBW_ARCHS_MACOS: x86_64 universal2
+      CIBW_TEST_SKIP: "*"
+      CIBW_BUILD: "cp38-*"
+      CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Add msbuild to PATH
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: delvewheel install
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install delvewheel==0.0.9 cython numpy
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.9.0
+
+      - name: Install wheels
+        shell: bash -l {0}
+        run: |
+          pip install ./wheelhouse/*.whl
+
+
+      - name: Run Tests after installing numpy (${{matrix.numpy_version}})
+        shell: bash -l {0}
+        run: |
+          pip install pytest pytest-cov
+          mv fastparquet fastparquet-src           #in order to avoid conflicts between the fastparquet directory and the fastparquet installed module
+          pip install ${{matrix.numpy_version}}    #installing a different numpy version than the one fastparquet wheel was compiled with
+          pytest --verbose --cov=fastparquet-src   #verifying that Fastparquet still works
+

--- a/.github/workflows/test_wheel.yaml
+++ b/.github/workflows/test_wheel.yaml
@@ -1,4 +1,4 @@
-name: Test PyPi wheels
+name: Test wheels
 
 on: [push, pull_request]
 
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-20.04, windows-2019]
         architecture: ['x64']
         linux_archs: ["native"]
-        numpy_version: ["numpy#latest", "numpy~=1.18.0", "numpy~=1.19.0", "numpy~=1.20.0", "numpy~=1.21.0"]
+        numpy_version: ["numpy~=1.18.0", "numpy~=1.19.0", "numpy~=1.20.0", "numpy~=1.21.0", "numpy#latest"]
         include:
           # https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
           - os: windows-2019
@@ -63,12 +63,11 @@ jobs:
         run: |
           pip install ./wheelhouse/*.whl
 
-
       - name: Run Tests after installing numpy (${{matrix.numpy_version}})
         shell: bash -l {0}
         run: |
           pip install pytest pytest-cov
-          mv fastparquet fastparquet-src           #in order to avoid conflicts between the fastparquet directory and the fastparquet installed module
+          mv ./fastparquet ./fastparquet-src           #in order to avoid conflicts between the fastparquet directory and the fastparquet installed module
           pip install ${{matrix.numpy_version}}    #installing a different numpy version than the one fastparquet wheel was compiled with
           pytest --verbose --cov=fastparquet-src   #verifying that Fastparquet still works
 

--- a/.github/workflows/test_wheel.yaml
+++ b/.github/workflows/test_wheel.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: delvewheel install
         if: runner.os == 'Windows'
         run: |
-          python -m pip install delvewheel==0.0.9 cython numpy
+          python -m pip install delvewheel==0.0.9 cython
 
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -53,7 +53,7 @@ jobs:
       - name: delvewheel install
         if: runner.os == 'Windows'
         run: |
-          python -m pip install delvewheel==0.0.9 cython numpy
+          python -m pip install delvewheel==0.0.9 cython
 
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -13,7 +13,7 @@ except ImportError:
     from pandas import Timestamp
 import pytest
 
-from fastparquet.test.util import tempdir
+from .util import tempdir
 import fastparquet
 from fastparquet import write, ParquetFile
 from fastparquet.api import statistics, sorted_partitioned_columns, filter_in, filter_not_in

--- a/fastparquet/test/test_aroundtrips.py
+++ b/fastparquet/test/test_aroundtrips.py
@@ -8,7 +8,7 @@ import pytest
 import fastparquet
 from fastparquet import write
 from fastparquet.compression import compressions
-from fastparquet.test.util import sql, s3, tempdir, TEST_DATA
+from .util import sql, s3, tempdir, TEST_DATA
 
 
 def test_map_array(sql):

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -12,7 +12,7 @@ from pandas.api.types import CategoricalDtype
 import pytest
 
 from fastparquet.util import default_mkdirs
-from fastparquet.test.util import s3, tempdir, sql, TEST_DATA
+from .util import s3, tempdir, sql, TEST_DATA
 from fastparquet import cencoding
 
 

--- a/fastparquet/test/test_overwrite.py
+++ b/fastparquet/test/test_overwrite.py
@@ -6,7 +6,7 @@
 import pandas as pd
 import pytest
 from fastparquet import write, ParquetFile
-from fastparquet.test.util import tempdir
+from .util import tempdir
 
 
 def test_write_with_rgp_by_date_as_index(tempdir):

--- a/fastparquet/test/test_partition_filters_specialstrings.py
+++ b/fastparquet/test/test_partition_filters_specialstrings.py
@@ -14,7 +14,7 @@ except ImportError:
     from pandas import Timestamp
 
 from fastparquet import write, ParquetFile
-from fastparquet.test.util import tempdir
+from .util import tempdir
 
 
 def frame_symbol_dtTrade_type_strike(days=1 * 252,

--- a/fastparquet/test/test_pd_optional_types.py
+++ b/fastparquet/test/test_pd_optional_types.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import fastparquet as fp
-from fastparquet.test.util import tempdir
+from .util import tempdir
 from fastparquet import write, parquet_thrift
 from fastparquet.parquet_thrift.parquet import ttypes as tt
 import numpy.random as random

--- a/fastparquet/test/test_read.py
+++ b/fastparquet/test/test_read.py
@@ -10,7 +10,7 @@ import fastparquet
 from fastparquet import writer, core
 from fastparquet.cencoding import NumpyIO
 
-from fastparquet.test.util import TEST_DATA, s3, tempdir
+from .util import TEST_DATA, s3, tempdir
 
 
 def test_header_magic_bytes(tempdir):

--- a/fastparquet/test/test_schema.py
+++ b/fastparquet/test/test_schema.py
@@ -6,7 +6,7 @@ import pytest
 
 from fastparquet import ParquetFile
 from fastparquet import write
-from fastparquet.test.util import tempdir
+from .util import tempdir
 
 
 def _generate_random_dataframe(n_rows=1000):

--- a/fastparquet/test/test_thrift_structures.py
+++ b/fastparquet/test/test_thrift_structures.py
@@ -3,7 +3,7 @@ import os
 import pickle
 
 from fastparquet import ParquetFile
-from fastparquet.test.util import TEST_DATA
+from .util import TEST_DATA
 from fastparquet.schema import schema_tree
 
 fn = os.path.join(TEST_DATA, "nation.impala.parquet")

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
     install_requires=install_requires,
     setup_requires=[
         'pytest-runner',
-    ] + [p for p in install_requires if p.startswith('numpy')],
+        'oldest-supported-numpy'
+    ],
     extras_require={
         'lzo': ['python-lzo'],
     },


### PR DESCRIPTION
This PR adds support for multiple versions of numpy and solves the "_numpy.ndarray size changed_" error.
Also, this PR contains an automated test to verify that the changes work as expected.

## Motivation of this PR

Currently, the user cannot install Fastparquet alongside an old version of numpy (e.g. 1.19.5 released on Jan 5, 2021).
This can be easily reproduced by doing something like: 
```
bash$ pip3 install fastparquet numpy==1.19.5
bash$ python3
>>> import fastparquet
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```
Issue #601 is related to this error and contains more information about it.

This PR fixes the error. The root cause of the error is that currently Fastparquet wheel is compiled against the newest numpy version, and according to the [numpy documentation](https://numpy.org/devdocs/user/depending_on_numpy.html#understanding-numpy-s-versioning-and-api-abi-stability) _binaries compiled against a given version of NumPy will still run correctly with newer NumPy versions, but not with older versions_



<br/>

## Description of the changes in this PR

This PR changes the version of numpy used during the compilation:
- `setup.py` is changed, so that instead of using the newest numpy release, Fastparquet is now compiled against the oldest supported numpy (using the [oldest-supported-numpy package](https://pypi.org/project/oldest-supported-numpy/))
- `wheel.yml` is also changed is a similar way (so that the latest version is no longer used to compile the Windows wheel)

Additionally, this PR adds a Github action to test it.
- `test_wheel.yaml` verifies that Fastparquet works as expected with old and new numpy versions. 
The test shows that before applying this PR, Fastparquet _cannot_ be used with numpy 1.18.x nor with 1.19.x [[link]](https://github.com/joseignaciorc/fastparquet/actions/runs/1064835278)
The test shows that after applying this PR, Fastparquet _can_ be used with numpy 1.18.x, 1.19.x, 1.20.x and 1.21.x [[link]](https://github.com/joseignaciorc/fastparquet/actions/runs/1064855817)

Finally, the import statements of some tests have been changed so that they can be run against the installed fastparquet wheel (instead of the fastparquet source code)