### PR TITLE
isadjustedttoUTC only when there is a tz

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -984,3 +984,16 @@ def test_cat_order(tempdir):
     out = ParquetFile(fn).to_pandas()
     assert out.cat.cat.ordered
     assert out.cat.cat.categories.tolist() == catdtype.categories.tolist()
+
+
+@pytest.mark.parametrize("tz", [True, False])
+def test_tz_local(tempdir, tz):
+    # #650
+    fn = os.path.join(tempdir, 'temp.parq')
+    df = pd.DataFrame({'a': [pd.to_datetime("now")]})
+    if tz:
+        df['a'] = df.a.dt.tz_localize("UTC")
+    write(fn, df)
+
+    pf = ParquetFile(fn)
+    assert pf.schema.schema_element(['a']).logicalType.TIMESTAMP.isAdjustedToUTC is tz

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -153,12 +153,13 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
     elif dtype.kind == "M":
         if times == 'int64':
             # output will have the same resolution as original data, for resolution <= ms
+            tz = getattr(dtype, "tz", None) is not None
             if "ns" in dtype.str:
                 type = parquet_thrift.Type.INT64
                 converted_type = None
                 logical_type = parquet_thrift.LogicalType(
                     TIMESTAMP=parquet_thrift.TimestampType(
-                        isAdjustedToUTC=True,
+                        isAdjustedToUTC=tz,
                         unit=parquet_thrift.TimeUnit(NANOS=parquet_thrift.NanoSeconds())
                     )
                 )
@@ -170,7 +171,7 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
                 )
                 logical_type = parquet_thrift.LogicalType(
                     TIMESTAMP=parquet_thrift.TimestampType(
-                        isAdjustedToUTC=True,
+                        isAdjustedToUTC=tz,
                         unit=parquet_thrift.TimeUnit(MICROS=parquet_thrift.MicroSeconds())
                     )
                 )
@@ -182,7 +183,7 @@ def find_type(data, fixed_text=None, object_encoding=None, times='int64'):
                 )
                 logical_type = parquet_thrift.LogicalType(
                     TIMESTAMP=parquet_thrift.TimestampType(
-                        isAdjustedToUTC=True,
+                        isAdjustedToUTC=tz,
                         unit=parquet_thrift.TimeUnit(MILLIS=parquet_thrift.MilliSeconds())
                     )
                 )


### PR DESCRIPTION
On writing, isadjustedttoUTC will be True only if the data has a non-None timezone.

Fixes #650