### PR TITLE
nth_val() method for ParquetFile.

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -640,11 +640,11 @@ class ParquetFile(object):
             * 'valid_call': `True` if N rows can be successfully accounted for
                from 'val', i.e. without modifying 'val'.
             * 'earlier': 'nth_val' if 'before' is `True`, or 'val' if 'before'
-               is `False`. If 'before' is `False` and if 'is_valid' is `False`
+               is `False`. If 'before' is `False` and if 'valid_call' is `False`
                then, instead of 'val', the latest value to comply with
                'n_rows' is provided.
             * 'later': 'nth_val' if 'before' is `False`, or 'val' if 'before'
-               is `True`. If 'before' is `True` and if 'is_valid' is `False`
+               is `True`. If 'before' is `True` and if 'valid_call' is `False`
                then, instead of 'val', the earliest value to comply with
                'n_rows' is provided.
 

--- a/fastparquet/test/test_api_addons.py
+++ b/fastparquet/test/test_api_addons.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+import pandas as pd
+import pytest
+from fastparquet import write, ParquetFile
+from .util import tempdir
+
+
+VAL = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2]
+DF = pd.DataFrame({'value' : VAL})
+RGO = [0,2,5,8,11]
+
+def test_nth_val_error(tempdir):
+    # Test 0 / raise error
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :      0    |         1        |       2       |      3      |  4
+    # values :  0.1  0.2 | 0.3  *  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                 0.31
+    n = 12
+    val = 0.31
+    with pytest.raises(ValueError, match="^13 rows are necessary"):
+        res = pf.nth_val('value', n, True, val)
+
+def test_nth_val_1(tempdir):
+    # Test 1 / 'val' within a row group.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :      0    |         1        |       2       |      3      |  4
+    # values :  0.1  0.2 | 0.3  *  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                 0.31
+    val = 0.31
+    res = pf.nth_val('value', 1, True, val)                 # before=True / n=1
+    assert res == (True, 0.3, val)
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.2, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.2, val)
+    res = pf.nth_val('value', 3, True, val)                 # before=True / n=3
+    assert res == (True, 0.1, val)
+    res = pf.nth_val('value', 1, False, val)               # before=False / n=1
+    assert res == (True, val, 0.4)
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.5)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.5)
+    res = pf.nth_val('value', 3, False, val)               # before=False / n=3
+    assert res == (True, val, 0.6)
+    res = pf.nth_val('value', 4, False, val)               # before=False / n=4
+    assert res == (True, val, 0.7)
+    res = pf.nth_val('value', 9, False, val)               # before=False / n=9
+    assert res == (True, val, 1.2)
+
+    # rg idx :      0    |       1          |       2       |      3      |  4
+    # values :  0.1  0.2 | 0.3  0.4  *  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                      0.41
+    val = 0.41
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.3, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.3, val)
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.6)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.6)
+
+def test_nth_val_2(tempdir):
+    # Test 2 / 'val' on a value.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                    0.4
+    val = 0.4
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.2, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.3, val)
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.6)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.5)
+
+def test_nth_val_3(tempdir):    
+    # Test 3 / 'val' outside.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # Test 3.0 / before  == True
+    # rg idx :     0    |       1       |       2       |      3      |  4
+    # values : 0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2  *
+    # val    :                                                              1.3
+    val = 1.3
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 1.1, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 1.1, val)
+
+    # rg idx :         0    |       1       |       2       |      3      |  4
+    # values :  *  0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :  0
+    val = 0
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.2)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.2)
+
+def test_nth_val_4(tempdir):  
+    # Test 4 / 'val' on a bound of a row group.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                                         0.8
+    val = 0.8
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.6, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.7, val)
+
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                               0.6
+    val = 0.6
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.4, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.5, val)
+
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :               0.3
+    val = 0.3
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.5)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.4)
+    
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                         0.5
+    val = 0.5
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.7)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.6)
+
+def test_nth_val_5(tempdir):  
+    # Test 5 / 'val' outside, leading to a roll in reversed direction.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :         0    |       1       |       2       |      3      |  4
+    # values :  *  0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :  0
+    val = 0
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (False, 0.1, 0.3)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (False, 0.1, 0.2)
+
+    # rg idx :     0    |       1       |       2       |      3      |  4
+    # values : 0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2  *
+    # val    :                                                              1.3
+    val = 1.3
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (False, 1.0, 1.2)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (False, 1.1, 1.2)
+    
+    # Other out of bound tests.
+    # rg idx :      0    |         1        |       2       |      3      |  4
+    # values :  0.1  0.2 | 0.3  *  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                 0.31
+    val = 0.31
+    res = pf.nth_val('value', 4, True, val)                # before=False / n=4
+    assert res == (False, 0.1, 0.5)
+    res = pf.nth_val('value', 10, False, val)             # before=False / n=10
+    assert res == (False, 0.2, 1.2)
+
+def test_nth_val_6(tempdir):
+    # Test 6 / no 'val'.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    : None (set by default to 1.2, the last value)
+    res = pf.nth_val('value', 2, True)                      # before=True / n=2
+    assert res == (True, 1.0, 1.2)
+    res = pf.nth_val('value', 2, True, exclude=False)       # before=True / n=2
+    assert res == (True, 1.1, 1.2)
+
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 | 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    : None (set by default to 0.1, the 1st value)
+    res = pf.nth_val('value', 2, False)                    # before=False / n=2
+    assert res == (True, 0.1, 0.3)
+    res = pf.nth_val('value', 2, False, exclude=False)     # before=False / n=2
+    assert res == (True, 0.1, 0.2)
+
+def test_nth_val_7(tempdir):   
+    # Test 7 / 'val' in-between 2 row groups.
+    # Test data.
+    write(tempdir, DF, row_group_offsets=RGO, file_scheme='hive')
+    pf = ParquetFile(tempdir)
+    # rg idx :        0    |       1       |       2       |      3      |  4
+    # values :    0.1  0.2 | 0.3  0.4  0.5 * 0.6  0.7  0.8 | 0.9  1  1.1 | 1.2
+    # val    :                            0.51
+    val = 0.51
+    res = pf.nth_val('value', 1, True, val)                 # before=True / n=1
+    assert res == (True, 0.5, val)
+    res = pf.nth_val('value', 2, True, val)                 # before=True / n=2
+    assert res == (True, 0.4, val)
+    res = pf.nth_val('value', 2, True, val, exclude=False)  # before=True / n=2
+    assert res == (True, 0.4, val)
+    res = pf.nth_val('value', 5, True, val)                 # before=True / n=5
+    assert res == (True, 0.1, val)
+
+    res = pf.nth_val('value', 1, False, val)               # before=False / n=1
+    assert res == (True, val, 0.6)
+    res = pf.nth_val('value', 2, False, val)               # before=False / n=2
+    assert res == (True, val, 0.7)
+    res = pf.nth_val('value', 2, False, val, exclude=False)# before=False / n=2
+    assert res == (True, val, 0.7)
+    res = pf.nth_val('value', 5, False, val)               # before=False / n=5
+    assert res == (True, val, 1.0)


### PR DESCRIPTION
Hi,

I would like to propose this implementation of a method able to return the nth value after or before a user defined value.
The docstring and the test cases are rather illustrative I suppose.

```python
    def nth_val(self, on: str, n_rows: int, before: bool=True, val: Any=None,
                exclude: bool=True) -> Tuple[bool, Any, Any]:
        """
        Return 'nth_val', i.e. the value of the nth row preceding or following
        'val', that can for instance be used later on in 'filters'.
        For the results to be correct, this function requires:
         - a sorted column in ascending order,
         - no duplicate values in the column,
        If there are no row enough and 'n_rows' cannot be accounted for, even
        by adjusting 'val' then an exception is raised.
        Search is made indistinctly of partitions that can be defined in the
        dataset (search is not restricted to the span of a specific partition).

        Parameters
        ----------
        on: str
            Name of the column in which looking for 'val' and 'nth_val'.
        n_rows: int
            Number of rows to account for before or after 'val'.
        before: bool, True
            If `True`, returns the nth value preceding 'val', otherwise the nth
            value following 'val'.
        val: Any, None
            A value of the same type as values contained in column 'on'. 'val'
            does not need to be present in 'on'.
            If 'val' is `None` and if 'before' is `True`, the nth value from
            tail is returned.
            If 'val' is `None` and if 'before' if `False`, the nth value from
            head is returned.
        exclude: bool, True
            If 'val' exists in 'on', and if 'exclude' is `True`, it is excluded
            from the N rows accounted for.

        Returns
        ----------
        valid_call, earlier, later: Tuple[bool, Any, Any]
            * 'valid_call': `True` if N rows can be successfully accounted for
               from 'val', i.e. without modifying 'val'.
            * 'earlier': 'nth_val' if 'before' is `True`, or 'val' if 'before'
               is `False`. If 'before' is `False` and if 'valid_call' is `False`
               then, instead of 'val', the latest value to comply with
               'n_rows' is provided.
            * 'later': 'nth_val' if 'before' is `False`, or 'val' if 'before'
               is `True`. If 'before' is `True` and if 'valid_call' is `False`
               then, instead of 'val', the earliest value to comply with
               'n_rows' is provided.

        """
```

At the moment, I don't request integration.
I have coded such a function some months ago in a private lib, that was working only in backward direction.
To implement the version proposed here, I rewrote completely my past implementation.
The numerous test cases are here to show that 'it works'.

But I would like to finalize the testing by interfacing it to my private lib, and confirm test cases of my private lib are ok.
I need to confirm the exclude/include logic in case the initial value is close to a boundary as per my initial implementation, which is the part of the code that has changed the most versus my initial implementation.

@martindurant 
yet, I anticipate that the implementation is near 100% ok on my side, and aware that an integration to fastparquet (that I acknowledge is not granted) needs time for careful review, please, do not hesitate to have a look and share your feedbacks.
I thank you in advance for your help.
Bests
