### PR TITLE
'head()' now fetches as many row groups as required to try matching required number of rows

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -231,12 +231,12 @@ class ParquetFile(object):
     def head(self, nrows, **kwargs):
         """Get the first nrows of data
 
-        This will load the whole of the first valid row-group for the
-        given columns. If it has fewer rows than requested, we will not
-        fetch more data.
+        This will load the whole of the first valid row-group for the given
+        columns.
 
-        kwargs can include things like columns, filters, etc., with
-        the same semantics as to_pandas()
+        kwargs can include things like columns, filters, etc., with the same
+        semantics as to_pandas(). If filters are applied, it may happen that
+        data is so reduced that 'nrows' is not ensured (fewer rows). 
 
         returns: dataframe
         """
@@ -245,7 +245,6 @@ class ParquetFile(object):
         total_rows = 0
         for i, rg in enumerate(self.row_groups):
             total_rows += rg.num_rows
-            print(f'total rows: {total_rows}')
             if total_rows >= nrows:
                 break
         return self[:i+1].to_pandas(**kwargs).head(nrows)

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -242,7 +242,13 @@ class ParquetFile(object):
         """
         # TODO: implement with truncated assign and early exit
         #  from reading
-        return self[:1].to_pandas(**kwargs).head(nrows)
+        total_rows = 0
+        for i, rg in enumerate(self.row_groups):
+            total_rows += rg.num_rows
+            print(f'total rows: {total_rows}')
+            if total_rows >= nrows:
+                break
+        return self[:i+1].to_pandas(**kwargs).head(nrows)
 
     def __getitem__(self, item):
         """Select among the row-groups using integer/slicing"""

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1067,6 +1067,16 @@ def test_head(tempdir):
     assert pf.head(1).val.tolist() == [2]
 
 
+def test_head(tempdir):
+    dn = os.path.join(tempdir, 'test_parquet')
+    val = [2, 10, 34, 76]
+    df = pd.DataFrame({'val': val})
+    write(dn, df, row_group_offsets=[0,2], file_scheme='hive')
+
+    pf = ParquetFile(dn)
+    assert pf.head(3).val.tolist() == [2, 10, 34]
+
+
 def test_spark_date_empty_rg():
     # https://github.com/dask/fastparquet/issues/634
     # first file has header size much smaller than others as it contains no row groups


### PR DESCRIPTION
Hi,
I would like to propose this change in `head()` so as to try fetching as many row groups as required to match `nrows`, in the event no filter is further applied.
(If further filters are applied, it may happen that data gets so much reduced that `nrows` is not matched in the end)