### PR TITLE
Update getstate with pandas_nulls

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -654,7 +654,8 @@ class ParquetFile(object):
         return dtype
 
     def __getstate__(self):
-        return {"fn": self.fn, "open": self.open, "sep": self.sep, "fmd": self.fmd}
+        return {"fn": self.fn, "open": self.open, "sep": self.sep, "fmd": self.fmd,
+                "pandas_nulls": self.pandas_nulls}
 
     def __setstate__(self, state):
         self.__dict__.update(state)


### PR DESCRIPTION
Fixes #663 

This condition only comes up for a case where the parquetFile gets serialised (e.g., for iter_row_groups) and contains nulls in columns which pandas has nullable types for (int/bool), so was missed by tests.