### PR TITLE
Code cleaning

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -93,7 +93,7 @@ class ParquetFile(object):
     _categories = None
 
     def __init__(self, fn, verify=False, open_with=default_open, root=False,
-                 fs=None, pandas_nulls=True):
+                 sep=None, fs=None, pandas_nulls=True):
         self.pandas_nulls = pandas_nulls
         if open_with is default_open and fs is None:
             fs = fsspec.filesystem("file")

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -92,8 +92,8 @@ class ParquetFile(object):
     _pdm = None
     _categories = None
 
-    def __init__(self, fn, verify=False, open_with=default_open,
-                 root=False, sep=None, fs=None, pandas_nulls=True):
+    def __init__(self, fn, verify=False, open_with=default_open, root=False,
+                 fs=None, pandas_nulls=True):
         self.pandas_nulls = pandas_nulls
         if open_with is default_open and fs is None:
             fs = fsspec.filesystem("file")
@@ -105,10 +105,8 @@ class ParquetFile(object):
             basepath, fmd = metadata_from_many(fn, verify_schema=verify,
                                                open_with=open_with, root=root,
                                                fs=fs)
-            if basepath:
-                self.fn = join_path(basepath, '_metadata')  # effective file
-            else:
-                self.fn = '_metadata'
+            self.fn = join_path(basepath, '_metadata') if basepath \
+                      else '_metadata'
             self.fmd = fmd
             self._set_attrs()
         elif hasattr(fn, 'read'):
@@ -149,16 +147,13 @@ class ParquetFile(object):
                     basepath, fmd = metadata_from_many(allfiles, verify_schema=verify,
                                                        open_with=open_with, root=root,
                                                        fs=fs)
-                    if basepath:
-                        self.fn = join_path(basepath, '_metadata')  # effective file
-                    else:
-                        self.fn = '_metadata'
+                    self.fn = join_path(basepath, '_metadata') if basepath \
+                              else '_metadata'
                     self.fmd = fmd
                     self._set_attrs()
             else:
                 raise FileNotFoundError
         self.open = open_with
-        self.sep = sep
         self._statistics = None
 
     def _parse_header(self, f, verify=True):
@@ -659,7 +654,7 @@ class ParquetFile(object):
         return dtype
 
     def __getstate__(self):
-        return {"fn": self.fn, "open": self.open, "sep": self.sep, "fmd": self.fmd,
+        return {"fn": self.fn, "open": self.open, "fmd": self.fmd,
                 "pandas_nulls": self.pandas_nulls}
 
     def __setstate__(self, state):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1117,9 +1117,7 @@ def write_common_metadata(fn, fmd, open_with=default_open,
         if no_row_groups:
             fmd = copy(fmd)
             fmd.row_groups = []
-            foot_size = write_thrift(f, fmd)
-        else:
-            foot_size = write_thrift(f, fmd)
+        foot_size = write_thrift(f, fmd)
         f.write(struct.pack(b"<i", foot_size))
         f.write(MARKER)
 
@@ -1170,13 +1168,8 @@ def merge(file_list, verify_schema=True, open_with=default_open,
     -------
     ParquetFile instance corresponding to the merged data.
     """
-    basepath, fmd = metadata_from_many(file_list, verify_schema, open_with,
-                                       root=root)
-
-    out_file = join_path(basepath, '_metadata')
-    write_common_metadata(out_file, fmd, open_with, no_row_groups=False)
-    out = api.ParquetFile(out_file, open_with=open_with)
-
-    out_file = join_path(basepath, '_common_metadata')
-    write_common_metadata(out_file, fmd, open_with)
+    out = api.ParquetFile(file_list, verify_schema, open_with, root)
+    write_common_metadata(out.fn, out.fmd, open_with, no_row_groups=False)
+    fn = f'{out.fn[:-9]}_common_metadata'
+    write_common_metadata(fn, out.fmd, open_with)
     return out

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -982,9 +982,10 @@ part files. This situation is not allowed with use of `append='overwrite'`.")
             else:
                 i_offset = find_max_part(fmd.row_groups)
         else:
+            # New dataset.
             i_offset = 0
+            mkdirs(filename)
 
-        mkdirs(filename)
         for i, start in enumerate(row_group_offsets):
             end = (row_group_offsets[i+1] if i < (len(row_group_offsets) - 1)
                    else None)


### PR DESCRIPTION
Miscellaneous 'cleanings' (so to say) after some code review:
- `sep` removal
- `mkdirs()` at a better place in `write()`
- rewrite of `merge()` to re-use 'higher level function' instead of `metadata_from_many`
- ...etc