### PR TITLE
Fix read_row_group_file to work with row_filter

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -293,7 +293,8 @@ class ParquetFile(object):
             if row_filter and isinstance(row_filter, list):
                 cs = self._columns_from_filters(row_filter)
                 df = self.read_row_group_file(
-                    rg, cs, index=False, infile=infile, row_filter=False)
+                    rg, cs, categories, index=False,
+                    infile=infile, row_filter=False)
                 row_filter = self._column_filter(df, filters=row_filter)
                 size = row_filter.sum()
                 if size == rg.num_rows:


### PR DESCRIPTION
I tried to call `read_row_group_file` with `row_filter` but it failed as follows.
It seems to be forgotten to pass the `categories` parameter.

```
In [1]: from fastparquet import ParquetFile

In [2]: pf = ParquetFile("test-data/test.parquet")

In [3]: pf.read_row_group_file(pf.row_groups[0], pf.columns, None, row_filter=[('f', '=', 0)])
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-1e2452704142> in <module>
----> 1 pf.read_row_group_file(pf.row_groups[0], pf.columns, None, row_filter=[('f', '=', 0)])

~/repos/fastparquet/fastparquet/api.py in read_row_group_file(self, rg, columns, categories, index, assign, partition_meta, row_filter, infile)
    293             if row_filter and isinstance(row_filter, list):
    294                 cs = self._columns_from_filters(row_filter)
--> 295                 df = self.read_row_group_file(
    296                     rg, cs, index=False, infile=infile, row_filter=False)
    297                 row_filter = self._column_filter(df, filters=row_filter)

TypeError: read_row_group_file() missing 1 required positional argument: 'categories'
```