### PR TITLE
[DO NOT MERGE] Returning fmd from write to show inconsistency

### DIFF
--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1107,7 +1107,7 @@ part files. This situation is not allowed with use of `append='overwrite'`.")
                               open_with)
     else:
         raise ValueError('File scheme should be simple|hive, not', file_scheme)
-
+    return fmd
 
 def find_max_part(row_groups):
     """


### PR DESCRIPTION
Hi @martindurant 
I started fixing conflicts between PR #712 and `main` branch.
Some bugs remain, and at the core, there is inconsistency that appears between a _read_ `fmd` and the `fmd` that remains after writing data to disk.

This 'dummy branch' (not to be merged) outputs `fmd` from write once data is written.

Before #633 (superthrift), the equality tested below was `True`. After superthrift, it is not any longer.
This is at least one of the reason why some test cases with  #712 are failing.
(I don't know if there are others)

```python
import pandas as pd
from fastparquet import ParquetFile, write

tempdir = '/home/yoh/Documents/code/data/fastparquet/'
partition=['b']
row_groups=[0,2]

df0 = pd.DataFrame({'a': [1, 2, 3, 0],
                    'b': ['a', 'b', 'a', 'b'],
                    'c': True})
fmd = write(tempdir, df0, partition_on=partition, file_scheme='hive',
      row_group_offsets=row_groups)
pf = ParquetFile(tempdir)
pf.fmd == fmd
Out[13]: False
```

Deep diving a bit both `file_scheme=simple` and `file_scheme=hive` cases, for `hive` case, I can notice that the binary type for `file_path` is not persisted when reading `ParquetFile` again.
```python
pf.fmd.row_groups[0].columns[0].file_path
Out[14]: 'b=a/part.0.parquet'

fmd.row_groups[0].columns[0].file_path
Out[15]: b'b=a/part.0.parquet'
```
I could not see the same in case `file_scheme=simple` because `file_path` is then for both `Nonetype`, but `fmd` are unequal as well.
Please, do you have any idea how solving this?