### PR TITLE
Slicing a ParquetFile does not modify initial ParquetFile.

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -278,7 +278,7 @@ class ParquetFile(object):
         new_rgs = self.row_groups[item]
         if not isinstance(new_rgs, list):
             new_rgs = [new_rgs]
-        new_pf = copy.copy(self)
+        new_pf = copy.deepcopy(self)
         new_pf.fmd.row_groups = new_rgs
         new_pf._set_attrs()
         # would otherwise be "simple" when selecting one rg
@@ -918,6 +918,20 @@ selection does not match number of rows in DataFrame.')
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        # Decode 'file_path'.
+        fmd = self.fmd
+        # for rg in fmd.row_groups:
+        for rg in fmd[4]:
+            # chunks = rg.columns
+            chunks = rg[1]    
+            if chunks:
+                chunk = chunks[0]
+                # s = chunk.file_path
+                s = chunk.get(1)
+                if s:
+                    # chunk.file_path = s.decode()
+                    chunk[1] = s.decode()
+        self.fmd = fmd
         self._set_attrs()
 
     def __str__(self):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -919,19 +919,14 @@ selection does not match number of rows in DataFrame.')
     def __setstate__(self, state):
         self.__dict__.update(state)
         # Decode 'file_path'.
-        fmd = self.fmd
-        # for rg in fmd.row_groups:
-        for rg in fmd[4]:
-            # chunks = rg.columns
-            chunks = rg[1]    
-            if chunks:
-                chunk = chunks[0]
-                # s = chunk.file_path
-                s = chunk.get(1)
-                if s:
-                    # chunk.file_path = s.decode()
-                    chunk[1] = s.decode()
-        self.fmd = fmd
+        rgs = self.fmd[4]
+        if rgs[0][1] and rgs[0][1][0] and rgs[0][1][0].get(1):
+            # for rg in fmd.row_groups:
+            for rg in rgs:
+                # chunk = rg.columns[0]
+                chunk = rg[1][0]
+                # chunk.file_path = chunk.file_path.decode()
+                chunk[1] = chunk.get(1).decode()
         self._set_attrs()
 
     def __str__(self):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -920,7 +920,10 @@ selection does not match number of rows in DataFrame.')
         self.__dict__.update(state)
         # Decode 'file_path'.
         rgs = self.fmd[4]
-        if rgs[0][1] and rgs[0][1][0] and rgs[0][1][0].get(1):
+        # Last if should not be necessary, depends on 'deepcopy' version
+        # https://github.com/dask/fastparquet/pull/731#issuecomment-1013507287
+        if (rgs[0][1] and rgs[0][1][0] and rgs[0][1][0].get(1)
+            and isinstance(rgs[0][1][0].get(1), bytes)):
             # for rg in fmd.row_groups:
             for rg in rgs:
                 # chunk = rg.columns[0]

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -920,7 +920,7 @@ selection does not match number of rows in DataFrame.')
         self.__dict__.update(state)
         # Decode 'file_path'.
         rgs = self.fmd[4]
-        # Last if should not be necessary, depends on 'deepcopy' version
+        # 4th condition should not be necessary, depends on 'deepcopy' version.
         # https://github.com/dask/fastparquet/pull/731#issuecomment-1013507287
         if (rgs[0][1] and rgs[0][1][0] and rgs[0][1][0].get(1)
             and isinstance(rgs[0][1][0].get(1), bytes)):

--- a/fastparquet/cencoding.pyx
+++ b/fastparquet/cencoding.pyx
@@ -772,8 +772,9 @@ cdef class ThriftObject:
         return self.copy()
 
     def __deepcopy__(self, memodict={}):
-        import pickle
-        return pickle.loads(pickle.dumps(self))
+        import copy
+        d = copy.deepcopy(self.data)
+        return ThriftObject(self.name, d)
 
     cpdef _asdict(self):
         """Create dict version with field names instead of integers"""

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1381,3 +1381,14 @@ def test_file_renaming_with_partitions(tempdir):
     expected_df['city'] = expected_df['city'].astype('category')
     expected_df = expected_df.reindex(columns=pf.to_pandas().columns)
     assert pf.to_pandas().equals(expected_df)
+
+
+def test_slicing_makes_copy(tempdir):
+    df = pd.DataFrame({'a':range(10)})
+    write(tempdir, df, row_group_offsets=2, file_scheme='hive')
+    pf_rec1 = ParquetFile(tempdir)
+    pf_sliced = pf_rec1[:2]
+    assert len(pf_sliced.row_groups) == 2
+    pf_rec2 = ParquetFile(tempdir)
+    assert pf_rec1.fmd.row_groups == pf_rec2.fmd.row_groups
+    assert pf_rec1.file_scheme == pf_rec2.file_scheme


### PR DESCRIPTION
Hello @martindurant,

I may be wrong, but given the way ``ParquetFile.__getitem__()`` is written, I think there is a bug that I correct here.
It all depends what is expected from this method:
- is it expected that it modifies current ``ParquetFile`` instance: this is what does current implementation
- or not, this is what proposes this PR by doing a deepcopy before slicing the row group list.

Given the way this method is written, by using a variable ``new_pf``, I think the 2nd way has been intended, but I may be wrong.
If the 1st way was intended, I don't think it is needed to use ``new_pf`` and return it. We could just modify ``fmd.row_groups`` in-place (meaning, no need to copy ``self`` with ``copy.copy``).

The 2nd way has been the one I expect, and I thus had some 'hard time' finding what has been going wrong in my code, with row groups mysteriously disappearing while I was using a `ParquetFile` instance, but not modifying explicitly its row groups.
([oups](https://github.com/yohplala/oups) under way :))

If I am right and this fix makes sense, a test is also enclosed.
Otherwise, if I am wrong in my guess, please ignore this PR.

PS: I had to modify `__setstate__` because `file_path`s re-appear as bytes during the `deepcopy`. But honestly, I have no great understanding what `__setstate__` does, and where does come from this `state` parameter? So please, if you accept this PR, you may want to double check this part to make sure it makes sense.

Bests