### PR TITLE
`partition_on` parameter in `write()` now accepts single string.

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -402,6 +402,12 @@ def test_single_upper_directory(tempdir):
     out = pf.to_pandas()
     assert (out.y == 'aa').all()
 
+def test_string_partition_name(tempdir):
+    df = pd.DataFrame({'x': [1, 5, 2, 5], 'yy': ['aa'] * 4})
+    write(tempdir, df, file_scheme='hive', partition_on='yy')
+    pf = ParquetFile(tempdir)
+    out = pf.to_pandas()
+    assert (out.yy == 'aa').all()
 
 def test_numerical_partition_name(tempdir):
     df = pd.DataFrame({'x': [1, 5, 2, 5], 'y1': ['aa', 'aa', 'bb', 'aa']})

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1156,6 +1156,8 @@ def write(filename, data, row_group_offsets=None,
                open_with=open_with, mkdirs=mkdirs, remove_with=None,
                stats=stats)
         return
+    if isinstance(partition_on, str):
+        partition_on = [partition_on]
     if append:
         pf = ParquetFile(filename, open_with=open_with)
         if pf._get_index():

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1093,10 +1093,10 @@ def write(filename, data, row_group_offsets=None,
         Whether or not to write the index to a separate column.  By default we
         write the index *if* it is not 0, 1, ..., n.
         Ignored if appending to an existing parquet data-set.
-    partition_on: list of column names
-        Passed to groupby in order to split data within each row-group,
-        producing a structured directory tree. Note: as with pandas, null
-        values will be dropped. Ignored if file_scheme is simple.
+    partition_on: string or list of string
+        Column names passed to groupby in order to split data within each
+        row-group, producing a structured directory tree. Note: as with pandas,
+        null values will be dropped. Ignored if file_scheme is simple.
         Checked when appending to an existing parquet dataset that requested
         partition column names match those of existing parquet data-set.
     fixed_text: {column: int length} or None


### PR DESCRIPTION
Closes: #556