### PR TITLE
First implementation of 'update_custom_metadata().

### DIFF
--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1419,3 +1419,33 @@ def test_not_quite_fsspec():
     assert out.to_pandas().to_dict() == {'a': {0: 0, 1: 1}, 'b': {0: 1, 1: 0}}
     out = ParquetFile("memory://out2.parq/_metadata", open_with=myopen)
     assert out.to_pandas().to_dict() == {'a': {0: 0, 1: 1}, 'b': {0: 1, 1: 0}}
+
+def test_update_kvm(tempdir):
+    df = pd.DataFrame({'a': [0, 1], 'b': [1, 0]})
+    custom_metadata = {'a':'test_a', 'b': 'test_b'}
+    write(tempdir, df, file_scheme='hive', custom_metadata=custom_metadata)
+    # Test existing custom metadata.
+    custom_metadata_b_ref = {key.encode(): value.encode()
+                             for key, value in custom_metadata.items()}
+    pf = ParquetFile(tempdir)
+    custom_metadata_b_rec = {key: value
+                             for key, value in pf.key_value_metadata.items()
+                             if key != b'pandas'}
+    assert custom_metadata_b_rec == custom_metadata_b_ref
+    # Test custom metadata update.
+    custom_metadata = {'a': None, 'b': 'test_b2', 'c': 'test_c', 'd': None}
+    pf.update_custom_metadata(custom_metadata, write_fmd=True)
+    custom_metadata_b_ref = {key.encode(): value.encode()
+                             for key, value in custom_metadata.items()
+                             if key not in ['a', 'd']}
+    custom_metadata_b_upd = {key: value
+                             for key, value in pf.key_value_metadata.items()
+                             if key != b'pandas'}
+    assert custom_metadata_b_upd == custom_metadata_b_ref
+    # Check values recorded are also ok.
+    pf2 = ParquetFile(tempdir)
+    custom_metadata_b_rec = {key: value
+                             for key, value in pf2.key_value_metadata.items()
+                             if key != b'pandas'}
+    assert custom_metadata_b_rec == custom_metadata_b_ref
+    


### PR DESCRIPTION
Here is a proposal to allow for updating custom metadata (ticket #613).

To be noticed, custom metadata resulting from the use of `update_custom_metadata()` are binary encoded, as it is currently the case when a `ParquetFile` instance is created from existing parquet files.

But:
- 1/ we could have them remaining strings in `ParquetFile` instance when using `update_custom_metadata()` (and they would still be binary encoded when being written to disk). If doing so, to commonize, I would propose to decode them when they are created from reading from a parquet files in `_parse_header()`:
  - in `_parse_header()`, similarly to how is decoded row group filename line [213](https://github.com/dask/fastparquet/blob/8d5ac3bd17ccf249d73650416f5cd63cc8402aa8/fastparquet/api.py#L213) This would decode values in `self.fmd.key_value_metadata` (which is a list)
  - in `set_attrs()`, `self.key_value_metadata` (which is a dict) would directly be initialized with decoded values from  `self.fmd.key_value_metadata`
- 2/ we can also keep them encoded as it currently is the case.
- 3/ we could also decide to not care about `self.fmd.key_value_metadata`, and only focus on `self.key_value_metadata` by turning it into a `property` and have the decoding directly in the `property` definition. The interest is to delay the decoding only if needed. We could actually use instead `@cached_property` to keep the decoded values once used once.

I think I would myself favor 3.
It seems to me `self.key_value_metadata` is likely the attribute called by the user (over `self.fmd.key_value_metadata`), and for this one, this would make sense to have the key/value available in a decoded form.

What would you recommend? (or would you recommend another option?)