### PR TITLE
Py36 was silently dropped when conda-forge did

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/tags/0.') || startsWith(${{github.event.commits[0].message}}, 'wheels')
+    if: startsWith(github.ref, 'refs/tags/0.')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -83,6 +82,6 @@ setup(
                       else ''),
     include_package_data=True,
     exclude_package_data={'fastparquet': ['test/*']},
-    python_requires=">=3.6,",
+    python_requires=">=3.7,",
     **extra
 )


### PR DESCRIPTION
Now remove from selectors, to prevent accidental wheel building.

May need updating wheel action on next release

Fixes #754