### PR TITLE
Making kvm a cached property with decoded keys/values.

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -427,7 +427,7 @@ def test_index(tempdir):
 
     pf = ParquetFile(fn)
     assert set(pf.columns) == {'x', 'y', 'z'}
-    meta = json.loads(pf.key_value_metadata[b'pandas'])
+    meta = json.loads(pf.key_value_metadata['pandas'])
     assert meta['index_columns'] == ['z']
     out = pf.to_pandas()
     assert out.index.name == 'z'
@@ -964,7 +964,7 @@ def test_custom_metadata(tempdir):
     fn = os.path.join(tempdir, 'temp.parq')
     write(fn, df, custom_metadata={"hello": "world"})
     pf = ParquetFile(fn)
-    assert pf.key_value_metadata[b'hello'] == b'world'
+    assert pf.key_value_metadata['hello'] == 'world'
 
 
 def test_cat_order(tempdir):

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1341,7 +1341,7 @@ def consolidate_categories(fmd):
                     if ncats and int(ncats[0]) > cat['metadata'][
                             'num_categories']:
                         cat['metadata']['num_categories'] = int(ncats[0])
-    key_value[2] = json.dumps(meta, sort_keys=True)
+    key_value[2] = json.dumps(meta, sort_keys=True).encode()
 
 
 def merge(file_list, verify_schema=True, open_with=default_open,


### PR DESCRIPTION
Hiu @martindurant ,
From my previous work, I have extracted the part that makes `ParquetFile.key_value_metadata` a cached property with decoded items.
I would like to propose to integrate this part of the work done.
The rational is that when recording metadata, these are not encoded items, and it seems to make sense the user retrieve them as decoded items.
Do you think this is acceptable?
Best regards,