### PR TITLE
Update custom md

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -21,3 +21,5 @@ API
 .. automethod:: ParquetFile.iter_row_groups
 
 .. autofunction:: write
+
+.. autofunction:: update_file_custom_metadata

--- a/fastparquet/__init__.py
+++ b/fastparquet/__init__.py
@@ -1,7 +1,7 @@
 """parquet - read parquet files."""
 __version__ = "0.8.1"
 
-from .writer import write
+from .writer import write, update_file_custom_metadata
 from . import core, schema, converted_types, api
 from .api import ParquetFile
 from .util import ParquetException

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 import pandas.testing as tm
 from fastparquet import ParquetFile
-from fastparquet import write, parquet_thrift
+from fastparquet import write, parquet_thrift, update_file_custom_metadata
 from fastparquet import writer, encoding
 from pandas.testing import assert_frame_equal
 from pandas.api.types import CategoricalDtype
@@ -1053,14 +1053,14 @@ def test_no_string(tmpdir):
     assert pd.isna(df2.A).all()
 
 
-def test_update_file_metadata(tempdir):
+def test_update_file_custom_metadata(tempdir):
     df = pd.DataFrame({'a': [0, 1]})
     custom_metadata_ref = {'a':'test_a', 'b': 'test_b'}
     write(tempdir, df, file_scheme='hive', custom_metadata=custom_metadata_ref)
     # Test custom metadata update in '_metadata'.
     custom_metadata_upd = {'a': None, 'b': 'test_b2', 'c': 'test_c', 'd': None}
     mdfn = os.path.join(tempdir, '_metadata')
-    writer.update_file_metadata(mdfn, custom_metadata_upd)
+    update_file_custom_metadata(mdfn, custom_metadata_upd)
     custom_metadata_upd_ref = {key: value
                                for key, value in custom_metadata_upd.items()
                                if key not in ['a', 'd']}
@@ -1080,7 +1080,7 @@ def test_update_file_metadata(tempdir):
                            if key != 'pandas'}
     assert custom_metadata_rec == custom_metadata_ref
     # Modify them in 'part.0.parquet' and check.
-    writer.update_file_metadata(datafn, custom_metadata_upd)  
+    update_file_custom_metadata(datafn, custom_metadata_upd)  
     pf = ParquetFile(datafn)
     custom_metadata_upd_rec = {key: value
                                for key, value in pf.key_value_metadata.items()

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -288,7 +288,7 @@ def update_custom_metadata(obj, custom_metadata : dict):
     -----
     Key-value metadata are expected binary encoded. This function ensures it
     is.
-    """       
+    """
     kvm = (obj.key_value_metadata if isinstance(obj, ThriftObject)
            else obj.fmd.key_value_metadata)
     # Spare list of keys.

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -15,6 +15,8 @@ import pandas as pd
 import fsspec
 from pandas.api.types import is_categorical_dtype
 
+from . import parquet_thrift
+from .cencoding import ThriftObject
 from fastparquet import __version__
 
 PANDAS_VERSION = LooseVersion(pd.__version__)
@@ -263,9 +265,61 @@ def _get_fmd(inbytes):
     return from_buffer(data, "FileMetaData")
 
 
+def update_custom_metadata(obj, custom_metadata : dict):
+    """Update custom metadata stored in thrift object or parquet file.
+
+    Update strategy depends if key found in new custom metadata is also found
+    in already existing custom metadata within thrift object, as well as its
+    value.
+        
+      - If not found in existing, it is added.
+      - If found in existing, it is updated.
+      - If its value is `None`, it is not added, and if found in existing,
+        it is removed from existing.
+
+    Parameters
+    ----------
+    obj : metadata ThriftObject or parquet file
+        Thrift object or parquet file which metadata is to update.
+    custom_metadata : dict
+        Key-value metadata to update in thrift object.
+        
+    Notes
+    -----
+    Key-value metadata are expected binary encoded. This function ensures it
+    is.
+    """       
+    kvm = (obj.key_value_metadata if isinstance(obj, ThriftObject)
+           else obj.fmd.key_value_metadata)
+    # Spare list of keys.
+    kvm_keys = [item.key for item in kvm]
+    for key, value in custom_metadata.items():
+        key_b = key.encode()
+        if key_b in kvm_keys:
+            idx = kvm_keys.index(key_b)
+            if value is None:
+                # Remove item.
+                del kvm[idx]
+                # Update 'kvm_keys' as well, for keeping indexing
+                # up-to-date.
+                del kvm_keys[idx]
+            else:
+                # Replace item.
+                kvm[idx] = parquet_thrift.KeyValue(key=key_b,
+                                                   value=value.encode())
+        elif value is not None:
+            kvm.append(parquet_thrift.KeyValue(key=key_b,
+                                               value=value.encode()))
+    if isinstance(obj, ThriftObject):
+        obj.key_value_metadata = kvm
+    else:
+        obj.fmd.key_value_metadata = kvm
+        # Reset '_kvm' to refresh 'key_value_metadata' cached property.
+        obj._kvm = None
+
+
 # simple cache to avoid re compile every time
 seps = {}
-
 
 def ex_from_sep(sep):
     """Generate regex for category folder matching"""

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -321,6 +321,7 @@ def update_custom_metadata(obj, custom_metadata : dict):
 # simple cache to avoid re compile every time
 seps = {}
 
+
 def ex_from_sep(sep):
     """Generate regex for category folder matching"""
     if sep not in seps:

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -19,11 +19,12 @@ from .compression import compress_data
 from .converted_types import tobson
 from .util import (default_open, default_mkdirs, check_column_names,
                    metadata_from_many, created_by, get_column_metadata,
-                   norm_col_name, path_string, reset_row_idx, get_fs)
+                   norm_col_name, path_string, reset_row_idx, get_fs,
+                   update_custom_metadata)
 from . import encoding, __version__
 from .speedups import array_encode_utf8, pack_byte_array
 from . import cencoding
-from .cencoding import NumpyIO, ThriftObject
+from .cencoding import NumpyIO, ThriftObject, from_buffer
 from decimal import Decimal
 
 MARKER = b'PAR1'
@@ -1486,3 +1487,52 @@ def overwrite(dirpath, data, row_group_offsets=None, sort_pnames:bool=True,
 def write_thrift(f, obj):
     # TODO inline this
     return f.write(obj.to_bytes())
+
+def update_file_metadata(path: str, custom_metadata: dict,
+                         is_metadata: bool = None):
+    """Update metadata in file without rewriting data portion if a data file.
+
+    Update strategy depends if key found in new custom metadata is also found
+    in already existing custom metadata within thrift object, as well as its
+    value.
+        
+      - If not found in existing, it is added.
+      - If found in existing, it is updated.
+      - If its value is `None`, it is not added, and if found in existing,
+        it is removed from existing.
+
+    Parameters
+    ----------
+    path : str
+        Path to file.
+    custom_metadata : dict
+        Key-value metadata to update in thrift object.
+    is_metadata : bool, default None
+        Define if target file is a pure metadata file, or is a parquet data
+        file. Depending file type, metadata is not stores at same location.
+        If `None`, is set depending file name.
+
+          - if ending with '_metadata', it assumes file is a metadata file.
+          - otherwise, it assumes it is a parquet data file.
+
+    """
+    if is_metadata is None:
+        if path[-9:] == '_metadata':
+            is_metadata = True
+        else:
+            is_metadata = False
+    with open(path, "rb+") as f:
+        if is_metadata:
+            loc = 4
+        else:
+            loc0 = f.seek(-8, 2)
+            size = int.from_bytes(f.read(4), "little")
+            loc = loc0 - size
+        f.seek(loc)
+        data = f.read()
+        fmd = from_buffer(data, "FileMetaData")
+        update_custom_metadata(fmd, custom_metadata)
+        f.seek(loc)
+        foot_size = write_thrift(f, fmd)
+        f.write(struct.pack(b"<I", foot_size))
+        f.write(b"PAR1")

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1504,16 +1504,19 @@ def update_file_metadata(path: str, custom_metadata: dict,
     Parameters
     ----------
     path : str
-        Path to file.
+        Local path to file.
     custom_metadata : dict
         Key-value metadata to update in thrift object.
     is_metadata : bool, default None
         Define if target file is a pure metadata file, or is a parquet data
-        file. Depending file type, metadata is not stores at same location.
-        If `None`, is set depending file name.
+        file. If `None`, is set depending file name.
 
           - if ending with '_metadata', it assumes file is a metadata file.
           - otherwise, it assumes it is a parquet data file.
+
+    Notes
+    -----
+    This method does not work for remote files.
 
     """
     if is_metadata is None:
@@ -1523,6 +1526,7 @@ def update_file_metadata(path: str, custom_metadata: dict,
             is_metadata = False
     with open(path, "rb+") as f:
         if is_metadata:
+            # For pure metadata file, metadata starts just four bytes in.
             loc = 4
         else:
             loc0 = f.seek(-8, 2)

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1488,10 +1488,12 @@ def write_thrift(f, obj):
     # TODO inline this
     return f.write(obj.to_bytes())
 
-def update_file_metadata(path: str, custom_metadata: dict,
-                         is_metadata: bool = None):
+def update_file_custom_metadata(path: str, custom_metadata: dict,
+                                is_metadata_file: bool = None):
     """Update metadata in file without rewriting data portion if a data file.
 
+    This function updates only the user key-values metadata, not the whole
+    metadata of a parquet file.
     Update strategy depends if key found in new custom metadata is also found
     in already existing custom metadata within thrift object, as well as its
     value.
@@ -1507,7 +1509,7 @@ def update_file_metadata(path: str, custom_metadata: dict,
         Local path to file.
     custom_metadata : dict
         Key-value metadata to update in thrift object.
-    is_metadata : bool, default None
+    is_metadata_file : bool, default None
         Define if target file is a pure metadata file, or is a parquet data
         file. If `None`, is set depending file name.
 
@@ -1517,9 +1519,8 @@ def update_file_metadata(path: str, custom_metadata: dict,
     Notes
     -----
     This method does not work for remote files.
-
     """
-    if is_metadata is None:
+    if is_metadata_file is None:
         if path[-9:] == '_metadata':
             is_metadata = True
         else:


### PR DESCRIPTION
Following discussion in PR #764, I am proposing to integrate an `update_custom_metadata`, which accepts as input either a metadata thrift object, either a parquet file (+ test case).
This function only operates on (in-memory) object, and does not modify any files on disk.

@martindurant ,
if you would like to extend it with file reading + modification, could it be managed by yet another function, that would call this one for metadata modification?  (in a separate PR?)
I am sorry, I don't feel confident to implement this part myself

Bests,