### PR TITLE
Use `packaging` for version parsing

### DIFF
--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -15,3 +15,4 @@ dependencies:
   - numpy
   - cramjam
   - pyspark
+  - packaging

--- a/ci/environment-py37.yml
+++ b/ci/environment-py37.yml
@@ -15,3 +15,4 @@ dependencies:
   - numpy
   - cramjam
   - pyspark
+  - packaging

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -15,3 +15,4 @@ dependencies:
   - numpy
   - cramjam
   - pyspark
+  - packaging

--- a/ci/environment-py38win.yml
+++ b/ci/environment-py38win.yml
@@ -14,3 +14,4 @@ dependencies:
   - thrift
   - numpy
   - cramjam
+  - packaging

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -15,3 +15,4 @@ dependencies:
   - numpy
   - cramjam
   - pyspark
+  - packaging

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -1,15 +1,17 @@
 import re
 from collections import OrderedDict
-from distutils.version import LooseVersion
+from packaging.version import Version
 import numpy as np
 from pandas import (
     Categorical, DataFrame, Series,
     CategoricalIndex, RangeIndex, Index, MultiIndex,
-    __version__ as pdver, DatetimeIndex
+    DatetimeIndex
 )
 from pandas.core.arrays.masked import BaseMaskedDtype
 from pandas.api.types import is_categorical_dtype
 import warnings
+
+from .util import PANDAS_VERSION
 
 
 class Dummy(object):
@@ -163,7 +165,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             x._set_categories = set_cats
 
             d = np.zeros(size, dtype=int)
-            if LooseVersion(pdver) >= LooseVersion("0.24.0"):
+            if PANDAS_VERSION >= Version("0.24.0"):
                 index._codes = list(index._codes) + [d]
             else:
                 index._labels.append(d)

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -4,7 +4,6 @@ import os
 from shutil import copytree
 import subprocess
 import sys
-from distutils.version import LooseVersion
 
 import fsspec
 import numpy as np

--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -1,17 +1,18 @@
-import distutils
 import shutil
 import warnings
 from unittest import mock
 
+from packaging.version import Version
 import pytest
 import pandas as pd
 from numpy import empty as np_empty
 from pandas.testing import assert_frame_equal
 
 from fastparquet.dataframe import empty
+from fastparquet.util import PANDAS_VERSION
 
 
-if distutils.version.LooseVersion(pd.__version__) >= "0.24.0":
+if PANDAS_VERSION >= Version("0.24.0"):
     DatetimeTZDtype = pd.DatetimeTZDtype
 else:
     DatetimeTZDtype = pd.api.types.DatetimeTZDtype

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import copy
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import lru_cache
 import io
 import struct
@@ -17,7 +17,7 @@ from pandas.api.types import is_categorical_dtype
 
 from fastparquet import __version__
 
-PANDAS_VERSION = LooseVersion(pd.__version__)
+PANDAS_VERSION = Version(pd.__version__)
 created_by = f"fastparquet-python version {__version__} (build 0)"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=1.1.0
 numpy>=1.18
 cramjam>=2.3.0
 fsspec
+packaging


### PR DESCRIPTION
Using `distutils` for version handling is now deprecated in favor of the `packaging` project maintained by PyPA. This PR updates `fastparquet` to use `packaging` instead of `distutils` which avoids deprecation warnings like

```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

from being emitted 