### PR TITLE
Initialize datetime indexes

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -133,7 +133,10 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             if hasattr(t, 'base'):
                 # funky pandas not-dtype
                  t = t.base
-            d = np.empty(size, dtype=t)
+            # Initialize datetime index to zero: uninitialized data might fail
+            # validation due to being an out-of-bounds datetime. xref
+            # https://github.com/dask/fastparquet/issues/778
+            d = np.zeros(size, dtype=t) if t.kind == "M" else np.empty(size, dtype=t)
             if d.dtype.kind == "M" and str(col) in timezones:
                 # 1) create the DatetimeIndex in UTC as no datetime conversion is needed and
                 # it works with d uninitialised data (no NonExistentTimeError or AmbiguousTimeError)

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -136,7 +136,8 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             # Initialize datetime index to zero: uninitialized data might fail
             # validation due to being an out-of-bounds datetime. xref
             # https://github.com/dask/fastparquet/issues/778
-            d = np.zeros(size, dtype=t) if t.kind == "M" else np.empty(size, dtype=t)
+            dtype = np.dtype(t)
+            d = np.zeros(size, dtype=dtype) if dtype.kind == "M" else np.empty(size, dtype=dtype)
             if d.dtype.kind == "M" and str(col) in timezones:
                 # 1) create the DatetimeIndex in UTC as no datetime conversion is needed and
                 # it works with d uninitialised data (no NonExistentTimeError or AmbiguousTimeError)

--- a/fastparquet/test/test_dataframe.py
+++ b/fastparquet/test/test_dataframe.py
@@ -70,6 +70,18 @@ def test_empty_tz_nonutc():
     assert df.a.dtype.tz.zone == "CET"
 
 
+# non-regression test for https://github.com/dask/fastparquet/issues/778
+def test_empty_valid_timestamp():
+    df, views = empty(
+        "i4",
+        size=100,
+        cols=["a"],
+        index_types=["datetime64[ms]"],
+        index_names=["timestamp"],
+    )
+    assert isinstance(df.index, pd.DatetimeIndex)
+
+
 def test_timestamps():
     z = 'US/Eastern'
 


### PR DESCRIPTION
Fixes #778. I still have to add tests. I suppose this is a bit slower to allocate for datetime indices, but it's better than failing.