### PR TITLE
Remove trailing comma at python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ setup(
                       else ''),
     include_package_data=True,
     exclude_package_data={'fastparquet': ['test/*']},
-    python_requires=">=3.7,",
+    python_requires=">=3.7",
     **extra
 )


### PR DESCRIPTION
Remove the trailing comma that causes poetry installation failure
Now the `python_requires` follows pep440
https://peps.python.org/pep-0440/

Fixes #784