### PR TITLE
Consolidate cats when loading from many files

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -9,7 +9,7 @@ import fsspec
 from fastparquet.util import join_path
 import pandas as pd
 
-from . import core, schema, converted_types, encoding, dataframe
+from . import core, schema, converted_types, encoding, dataframe, writer
 from . import parquet_thrift
 from .cencoding import ThriftObject, from_buffer
 from .util import (default_open, default_remove, ParquetException, val_to_num,
@@ -120,6 +120,7 @@ class ParquetFile(object):
             basepath, fmd = metadata_from_many(fn, verify_schema=verify,
                                                open_with=open_with, root=root,
                                                fs=fs)
+            writer.consolidate_categories(fmd)
             self.fn = join_path(
                 basepath, '_metadata') if basepath else '_metadata'
             self.fmd = fmd
@@ -160,6 +161,7 @@ class ParquetFile(object):
                     basepath, fmd = metadata_from_many(allfiles, verify_schema=verify,
                                                        open_with=open_with, root=root,
                                                        fs=fs)
+                    writer.consolidate_categories(fmd)
                     self.fn = join_path(basepath, '_metadata') if basepath \
                               else '_metadata'
                     self.fmd = fmd

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -18,10 +18,10 @@ from .api import ParquetFile, partitions, part_ids
 from .compression import compress_data
 from .converted_types import tobson
 from .util import (default_open, default_mkdirs, check_column_names,
-                   metadata_from_many, created_by, get_column_metadata,
+                   created_by, get_column_metadata,
                    norm_col_name, path_string, reset_row_idx, get_fs,
                    update_custom_metadata)
-from . import encoding, __version__
+from . import __version__
 from .speedups import array_encode_utf8, pack_byte_array
 from . import cencoding
 from .cencoding import NumpyIO, ThriftObject, from_buffer


### PR DESCRIPTION
A fix for #789 when running via fastparquet directly. Probably still broken in dask. @sophiamyang would you mind testing?