### PR TITLE
Adding `__len__`, `__bool__` in `ParquetFile` and bugfix in 'pf.remove_row_groups()'.

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -320,8 +320,8 @@ class ParquetFile(object):
             return 0
 
     def __bool__(self):
-        """Return True if path defined."""
-        return bool(self.fn)
+        """Return True, takes precedence over `__len__`."""
+        return True
 
     def row_group_filename(self, rg):
         if rg.columns and rg.columns[0].file_path:

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -314,7 +314,10 @@ class ParquetFile(object):
 
     def __len__(self):
         """Return number of row groups."""
-        return len(self.fmd.row_groups)
+        if self.fmd.row_groups:
+            return len(self.fmd.row_groups)
+        else:
+            return 0
 
     def row_group_filename(self, rg):
         if rg.columns and rg.columns[0].file_path:

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -312,6 +312,10 @@ class ParquetFile(object):
         new_pf.file_scheme = self.file_scheme
         return new_pf
 
+    def __len__(self):
+        """Return number of row groups."""
+        return len(self.fmd.row_groups)
+
     def row_group_filename(self, rg):
         if rg.columns and rg.columns[0].file_path:
             base = self.basepath
@@ -434,14 +438,20 @@ class ParquetFile(object):
                 or self.file_scheme == 'flat'):
                 # Check if some files contain row groups both to be removed and
                 # to be kept.
-                all_rgs = row_groups_map(self.row_groups)
+                all_rgs = row_groups_map(self.fmd.row_groups)
                 for file in rgs_to_remove:
                     if len(rgs_to_remove[file]) < len(all_rgs[file]):
                         raise ValueError(
                             f"File {file} contains row groups both to be kept "
                             "and to be removed. Removing row groups partially "
                             "from a file is not possible.")
-            rg_new = self.row_groups
+            if rgs != self.fmd.row_groups:
+                rg_new = self.fmd.row_groups
+            else:
+                # Deep copy required if 'rg_new' and 'rgs' points both to
+                # 'self.fmd.row_groups'.
+                from copy import deepcopy
+                rg_new = deepcopy(self.fmd.row_groups)
             for rg in rgs:
                 rg_new.remove(rg)
                 self.fmd.num_rows -= rg.num_rows

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -319,11 +319,9 @@ class ParquetFile(object):
         else:
             return 0
 
-
     def __bool__(self):
         """Return True if path defined."""
         return bool(self.fn)
-
 
     def row_group_filename(self, rg):
         if rg.columns and rg.columns[0].file_path:

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -319,6 +319,12 @@ class ParquetFile(object):
         else:
             return 0
 
+
+    def __bool__(self):
+        """Return True if path defined."""
+        return bool(self.fn)
+
+
     def row_group_filename(self, rg):
         if rg.columns and rg.columns[0].file_path:
             base = self.basepath

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1442,7 +1442,3 @@ def test_len_and_bool(tempdir):
     write(dn, df, file_scheme='hive', row_group_offsets=[0,2])
     pf = ParquetFile(dn)
     assert len(pf) == 2
-    # When not defined, __bool__ is implicitly substituted by __len__
-    assert pf
-    pf.remove_row_groups(pf.row_groups)
-    assert not pf

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1246,6 +1246,16 @@ def test_remove_rgs_partitioned_pyarrow_multi(tempdir):
     assert pf.to_pandas().equals(df_ref) 
 
 
+def test_remove_all_rgs(tempdir):
+    dn = os.path.join(tempdir, 'test_parquet')
+    write(dn, df_remove_rgs, file_scheme='hive', partition_on=['city'])
+    pf = ParquetFile(dn)
+    assert len(pf.row_groups) == 3 # check number of row groups
+    # Remove all row groups and check there is no row group anymore.
+    pf.remove_row_groups(pf.row_groups)
+    assert len(pf.row_groups) == 0 # check row group list updated
+
+
 def test_remove_rgs_simple_merge(tempdir):
     df = pd.DataFrame({'a':range(4), 'b':['lo']*2+['hi']*2})
     fn = os.path.join(tempdir, 'fn1.parquet')
@@ -1418,3 +1428,21 @@ def test_not_quite_fsspec():
     assert out.to_pandas().to_dict() == {'a': {0: 0, 1: 1}, 'b': {0: 1, 1: 0}}
     out = ParquetFile("memory://out2.parq/_metadata", open_with=myopen)
     assert out.to_pandas().to_dict() == {'a': {0: 0, 1: 1}, 'b': {0: 1, 1: 0}}
+
+
+def test_len_and_bool(tempdir):
+    dn = os.path.join(tempdir, 'test_parquet')
+    fn = os.path.join(tempdir, 'test.parquet')
+    df = pd.DataFrame({'val': [0.3, 0.8, 0.9]})
+    # Write simple.
+    write(fn, df)
+    pf = ParquetFile(fn)
+    assert len(pf) == 1
+    # Write multi.
+    write(dn, df, file_scheme='hive', row_group_offsets=[0,2])
+    pf = ParquetFile(dn)
+    assert len(pf) == 2
+    # When not defined, __bool__ is implicitly substituted by __len__
+    assert pf
+    pf.remove_row_groups(pf.row_groups)
+    assert not pf


### PR DESCRIPTION
- Implement `__len__` in `ParquetFile` class.
  Based on the logic iterating a `ParquetFile` object returns row groups, `__len__` returns the number of row groups.

- Implement `__bool__` in `ParquetFile` class.
  `__bool__` is implemented as a fix for correct run of dask test cases. In dask, a `ParquetFile` object is considered `True` as long as the object is defined. But if not having `__bool__` in an object definition while having `__len__`, then the boolean state is checked calling `__len__`. Thus the boolean state was changed if only having `__len__` but not `__bool__`.

- Fixed a bug at the same time in `ParquetFile.remove_row_groups()` occuring when calling it to remove all row groups of a `ParquetFile` object this way (a `for` loop within the method would then not produce the expected behavior) :
```python
pf.remove_row_groups(pf.row_groups)
```

- + test cases