### PR TITLE
Use custom json encoder

### DIFF
--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -16,3 +16,6 @@ dependencies:
   - cramjam
   - pyspark
   - packaging
+  - orjson
+  - ujson
+  - python-rapidjson

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -16,3 +16,6 @@ dependencies:
   - cramjam
   - pyspark
   - packaging
+  - orjson
+  - ujson
+  - python-rapidjson

--- a/ci/environment-py38win.yml
+++ b/ci/environment-py38win.yml
@@ -15,3 +15,6 @@ dependencies:
   - numpy
   - cramjam
   - packaging
+  - orjson
+  - ujson
+  - python-rapidjson

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -16,3 +16,6 @@ dependencies:
   - cramjam
   - pyspark
   - packaging
+  - orjson
+  - ujson
+  - python-rapidjson

--- a/docs/source/details.rst
+++ b/docs/source/details.rst
@@ -145,6 +145,17 @@ If the 'element' type is anything other than a primitive type,
 i.e., a struct, map or list, than fastparquet will not be able to read it, and the resulting
 column will either not be contained in the output, or contain only ``None`` values.
 
+Object encoding
+---------------
+
+Object columns are Json encoded and decoded if the data type is ``json``,
+as specified by the ``object_encoding`` parameter in ``fastparquet.write``.
+
+If any of the libraries ``orjson``, ``ujson``, ``python-rapidjson`` is installed,
+then it's used in place of the ``json`` module in the Python Standard Library.
+
+Using one of these libraries may improve both the reading and writing performance.
+
 Partitions and row-groups
 -------------------------
 

--- a/docs/source/details.rst
+++ b/docs/source/details.rst
@@ -156,6 +156,14 @@ then it's used in place of the ``json`` module in the Python Standard Library.
 
 Using one of these libraries may improve both the reading and writing performance.
 
+You can also enforce the use of a specific library by setting the environment variable
+``FASTPARQUET_JSON_CODEC`` to one of the supported modules:
+
+* ``orjson``
+* ``ujson``
+* ``rapidjson``
+* ``json``
+
 Partitions and row-groups
 -------------------------
 

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -12,9 +12,10 @@ import pandas as pd
 from . import core, schema, converted_types, encoding, dataframe, writer
 from . import parquet_thrift
 from .cencoding import ThriftObject, from_buffer
+from .json import json_decoder
 from .util import (default_open, default_remove, ParquetException, val_to_num,
                    ops, ensure_bytes, ensure_str, check_column_names, metadata_from_many,
-                   ex_from_sep, json_decoder, _strip_path_tail, get_fs)
+                   ex_from_sep, _strip_path_tail, get_fs)
 
 
 # Find in names of partition files the integer matching "**part.*.parquet",

--- a/fastparquet/converted_types.py
+++ b/fastparquet/converted_types.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from . import parquet_thrift
 from .cencoding import time_shift
-from .util import json_decoder
+from .json import json_decoder
 
 logger = logging.getLogger('parquet')  # pylint: disable=invalid-name
 

--- a/fastparquet/json.py
+++ b/fastparquet/json.py
@@ -1,0 +1,97 @@
+import logging
+from abc import ABC, abstractmethod
+from functools import lru_cache
+
+logger = logging.getLogger("parquet")
+
+
+class BaseImpl(ABC):
+    @abstractmethod
+    def dumps(self, data):
+        """Serialize ``obj`` to a JSON formatted bytes instance containing UTF-8 data."""
+
+    @abstractmethod
+    def loads(self, s):
+        """Deserialize ``s`` (str, bytes or bytearray containing JSON) to a Python object."""
+
+
+class OrjsonImpl(BaseImpl):
+    def __init__(self):
+        import orjson
+
+        logger.debug("Using orjson encoder/decoder")
+        self.api = orjson
+
+    def dumps(self, data):
+        return self.api.dumps(data, option=self.api.OPT_SERIALIZE_NUMPY)
+
+    def loads(self, s):
+        return self.api.loads(s)
+
+
+class UjsonImpl(BaseImpl):
+    def __init__(self):
+        import ujson
+
+        logger.debug("Using ujson encoder/decoder")
+        self.api = ujson
+
+    def dumps(self, data):
+        return self.api.dumps(
+            data,
+            ensure_ascii=False,
+            escape_forward_slashes=False,
+        ).encode("utf-8")
+
+    def loads(self, s):
+        return self.api.loads(s)
+
+
+class RapidjsonImpl(BaseImpl):
+    def __init__(self):
+        import rapidjson
+
+        logger.debug("Using rapidjson encoder/decoder")
+        self.api = rapidjson
+
+    def dumps(self, data):
+        return self.api.dumps(data, ensure_ascii=False).encode("utf-8")
+
+    def loads(self, s):
+        return self.api.loads(s)
+
+
+class JsonImpl(BaseImpl):
+    def __init__(self):
+        import json
+
+        logger.debug("Using json encoder/decoder")
+        self.api = json
+
+    def dumps(self, data):
+        return self.api.dumps(data, separators=(",", ":")).encode("utf-8")
+
+    def loads(self, s):
+        return self.api.loads(s)
+
+
+@lru_cache(maxsize=None)
+def _get_json_impl():
+    """Return the first available json encoder/decoder implementation."""
+    for engine_class in [OrjsonImpl, UjsonImpl, RapidjsonImpl]:
+        try:
+            return engine_class()
+        except ImportError:
+            pass
+    # slower but always available
+    return JsonImpl()
+
+
+def json_encoder():
+    """Return the first available json encoder function."""
+    return _get_json_impl().dumps
+
+
+def json_decoder():
+    """Return the first available json decoder function."""
+    return _get_json_impl().loads

--- a/fastparquet/test/test_json.py
+++ b/fastparquet/test/test_json.py
@@ -1,0 +1,82 @@
+from typing import Callable
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from fastparquet import json
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        [1, 1, 2, 3, 5],
+        [1.23, -3.45],
+        [np.float64(0.12), np.float64(4.56)],
+        [[1, 2, 4], ["x", "y", "z"]],
+        {"k1": "value", "k2": "à/è", "k3": 3},
+        {"k1": [1, 2, 3], "k2": [4.1, 5.2, 6.3]},
+    ],
+)
+@pytest.mark.parametrize(
+    "encoder_module, encoder_class",
+    [
+        ("orjson", json.OrjsonImpl),
+        ("ujson", json.UjsonImpl),
+        ("rapidjson", json.RapidjsonImpl),
+        ("json", json.JsonImpl),
+    ],
+)
+@pytest.mark.parametrize(
+    "decoder_module, decoder_class",
+    [
+        ("orjson", json.OrjsonImpl),
+        ("ujson", json.UjsonImpl),
+        ("rapidjson", json.RapidjsonImpl),
+        ("json", json.JsonImpl),
+    ],
+)
+def test_engine(encoder_module, encoder_class, decoder_module, decoder_class, data):
+    pytest.importorskip(encoder_module)
+    pytest.importorskip(decoder_module)
+
+    encoder_obj = encoder_class()
+    decoder_obj = decoder_class()
+
+    dumped = encoder_obj.dumps(data)
+    assert isinstance(dumped, bytes)
+
+    loaded = decoder_obj.loads(dumped)
+    assert loaded == data
+
+
+@pytest.mark.parametrize(
+    "module, impl_class",
+    [
+        ("orjson", json.OrjsonImpl),
+        ("ujson", json.UjsonImpl),
+        ("rapidjson", json.RapidjsonImpl),
+        ("json", json.JsonImpl),
+    ],
+)
+def test__get_json_impl(module, impl_class):
+    pytest.importorskip(module)
+
+    json._get_json_impl.cache_clear()
+    missing_modules = {"orjson", "ujson", "rapidjson"} - {module}
+    with patch.dict("sys.modules", {mod: None for mod in missing_modules}):
+        result = json._get_json_impl()
+    assert isinstance(result, impl_class)
+
+
+def test_json_encoder():
+    json._get_json_impl.cache_clear()
+    result = json.json_encoder()
+    assert isinstance(result, Callable)
+
+
+def test_json_decoder():
+    json._get_json_impl.cache_clear()
+    result = json.json_decoder()
+    assert isinstance(result, Callable)

--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -502,22 +502,6 @@ def join_path(*path):
     return "/".join([p.replace("\\", "/").rstrip("/") for p in path if p])
 
 
-_json_decoder = [None]
-
-
-def json_decoder():
-    import importlib
-    if _json_decoder[0] is None:
-        for lib in ['orjson', 'ujson', 'rapidjson', 'json']:
-            try:
-                package = importlib.import_module(lib)
-                _json_decoder[0] = package.loads
-                break
-            except (ImportError, AttributeError):
-                pass
-    return _json_decoder[0]
-
-
 def _strip_path_tail(paths) -> set:
     return {path.rsplit("/", 1)[0] if "/" in path else "" for path in paths}
 

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -17,6 +17,7 @@ from . import parquet_thrift
 from .api import ParquetFile, partitions, part_ids
 from .compression import compress_data
 from .converted_types import tobson
+from .json import json_encoder
 from .util import (default_open, default_mkdirs, check_column_names,
                    created_by, get_column_metadata,
                    norm_col_name, path_string, reset_row_idx, get_fs,
@@ -272,9 +273,10 @@ def convert(data, se):
                 else:
                     out = data.values
             elif converted_type == parquet_thrift.ConvertedType.JSON:
-                # TODO: avoid list, use better JSON
-                out = np.array([json.dumps(x).encode('utf8') for x in data],
-                               dtype="O")
+                encoder = json_encoder()
+                # TODO: avoid list. np.fromiter can be used with numpy >= 1.23.0,
+                #  but older versions don't support object arrays.
+                out = np.array([encoder(x) for x in data], dtype="O")
             elif converted_type == parquet_thrift.ConvertedType.BSON:
                 out = data.map(tobson).values
             if type == parquet_thrift.Type.FIXED_LEN_BYTE_ARRAY:


### PR DESCRIPTION
Use the same json library for both encoding and decoding.
Fallback based on installed libraries:
- orjson
- ujson
- python-rapidjson
- json (from the standard library)

For testing, all the libraries are installed in the existing environments.
Alternatively, to run all the tests with `json` as before, it's possible to create new environments with the additional json libraries.