### PR TITLE
Fixing inconsistent naming of 'is_metadata_file' flag.

### DIFF
--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -1161,6 +1161,17 @@ def test_update_file_custom_metadata(tempdir):
     assert custom_metadata_upd_rec == custom_metadata_upd_ref
 
 
+def test_update_file_custom_metadata_2(tempdir):
+    # Modifying metadata in a parquet file, specifying it is a parquet file.
+    df = pd.DataFrame([1, 2, 3], columns=["a"])
+    fn = os.path.join(tempdir, "data.parquet")
+    write(fn, df)
+    metadata = {"version": "1"}
+    update_file_custom_metadata(fn, custom_metadata=metadata, is_metadata_file=False)
+    pf = ParquetFile(fn)
+    assert pf.key_value_metadata["version"] == "1"
+
+
 def test_json_stats(tempdir):
     # https://github.com/dask/fastparquet/issues/775
     df = pd.DataFrame(

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1573,11 +1573,11 @@ def update_file_custom_metadata(path: str, custom_metadata: dict,
     """
     if is_metadata_file is None:
         if path[-9:] == '_metadata':
-            is_metadata = True
+            is_metadata_file = True
         else:
-            is_metadata = False
+            is_metadata_file = False
     with open(path, "rb+") as f:
-        if is_metadata:
+        if is_metadata_file:
             # For pure metadata file, metadata starts just four bytes in.
             loc = 4
         else:


### PR DESCRIPTION
Fixes #829 
Test case added, based on the test submitted in ticket.