### PR TITLE
Roundtrip tz for multi-index/categorical columns

### DIFF
--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -472,7 +472,10 @@ def read_col(column, schema_helper, infile, use_cat=False,
             if use_cat and dic is not None:
                 # fastpath skips the check the number of categories hasn't changed.
                 # In this case, they may change, if the default RangeIndex was used.
-                catdef._set_categories(pd.Index(dic), fastpath=True)
+                ddt = [kv.value.decode() for kv in cmd.key_value_metadata
+                       if kv.key == b"label_dtype"]
+                ddt = ddt[0] or None
+                catdef._set_categories(pd.Index(dic, dtype=ddt), fastpath=True)
                 if np.iinfo(assign.dtype).max < len(dic):
                     raise RuntimeError('Assigned array dtype (%s) cannot accommodate '
                                        'number of category labels (%i)' %

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -474,7 +474,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
                 # In this case, they may change, if the default RangeIndex was used.
                 ddt = [kv.value.decode() for kv in (cmd.key_value_metadata or [])
                        if kv.key == b"label_dtype"]
-                ddt = ddt[0] or None
+                ddt = ddt[0] if ddt else None
                 catdef._set_categories(pd.Index(dic, dtype=ddt), fastpath=True)
                 if np.iinfo(assign.dtype).max < len(dic):
                     raise RuntimeError('Assigned array dtype (%s) cannot accommodate '

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -472,7 +472,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
             if use_cat and dic is not None:
                 # fastpath skips the check the number of categories hasn't changed.
                 # In this case, they may change, if the default RangeIndex was used.
-                ddt = [kv.value.decode() for kv in cmd.key_value_metadata
+                ddt = [kv.value.decode() for kv in (cmd.key_value_metadata or [])
                        if kv.key == b"label_dtype"]
                 ddt = ddt[0] or None
                 catdef._set_categories(pd.Index(dic, dtype=ddt), fastpath=True)

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1006,6 +1006,27 @@ def test_multi(tempdir):
     assert (df1.loc[1, 'a'].values == df.loc[1, 'a'].values).all()
 
 
+def test_multi_dtype(tempdir):
+    # https://github.com/dask/fastparquet/issues/831
+    fn = os.path.join(tempdir, 'test.parq')
+    idx = [
+        pd.Timestamp("2022-12-01 13:00", tz="UTC"),
+        pd.Timestamp("2022-12-01 14:00", tz="UTC"),
+    ]
+    data = [
+        [1, 55],
+        [2, 56],
+    ]
+    df = pd.DataFrame(data=data, index=idx, columns=["seq", "val"])
+    df.index.name = "time"
+    df.set_index("seq", append=True, inplace=True)
+    fastparquet.write(fn, df)
+
+    pf = fastparquet.ParquetFile(fn)
+    df2 = pf.to_pandas()
+    assert df.equals(df2)
+
+
 def test_simple_nested():
     fn = os.path.join(TEST_DATA, 'nested1.parquet')
     pf = ParquetFile(fn)

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -531,6 +531,7 @@ def write_column(f, data, selement, compression=None, datapage_version=None,
         except (TypeError, ValueError):
             stats = False
         ncats = len(data.cat.categories)
+        dcat = data.cat.categories.dtype
         data = data.cat.codes
         cats = True
         encoding = "RLE_DICTIONARY"
@@ -667,6 +668,8 @@ def write_column(f, data, selement, compression=None, datapage_version=None,
             parquet_thrift.KeyValue(key='num_categories', value=str(ncats)))
         kvm.append(
             parquet_thrift.KeyValue(key='numpy_dtype', value=str(data.dtype)))
+        kvm.append(
+            parquet_thrift.KeyValue(key='label_dtype', value=str(dcat)))
     chunk = parquet_thrift.ColumnChunk(file_offset=offset,
                                        meta_data=cmd,
                                        file_path=None)


### PR DESCRIPTION
ref #831 

@2-5 this fixes your very specific case of fastparquet-fastparquet roundtrip. I believe loading fastparquet data with arrow would already have worked (because the same information is in the parquet schema) and arrow data loads OK with fastparquet (but somewhat less efficiently because we don't know that the multiindex labels must be categorical). 
