### PR TITLE
Preserve columns dtype when columnns=[] is given

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -117,7 +117,8 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                                   "" % (timezones[str(col)], col))
             df[str(col)] = d
 
-    df = DataFrame(df, columns=df.keys())
+    columns = [] if len(df) == 0 else None
+    df = DataFrame(df, columns=columns)
     if not index_types:
         index = RangeIndex(size)
     elif len(index_types) == 1:


### PR DESCRIPTION
The current pandas nightly version causes 

```
FAILED fastparquet/test/test_read.py::test_no_columns - AssertionError: DataFrame.columns are different
```

to fail. 

This pr makes things consistent again:

```
pd.read_parquet(fn, columns=[])
```

behaves as

```
pd.read_parquet(fn)[]
```

We get an empty RangeIndex without specifying the columns, which is counterintuitive for parquet files.