### PR TITLE
Allow selecting column for cat output when only one row-group

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -857,7 +857,7 @@ selection does not match number of rows in DataFrame.')
             return cats or {}
         if cats is None:
             return categ or {}
-        if set(cats) - set(categ):
+        if set(cats) - set(categ) and len(self.row_groups) > 1:
             raise TypeError("Attempt to read as category a field that "
                             "was not stored as such")
         if isinstance(cats, dict):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -862,7 +862,9 @@ selection does not match number of rows in DataFrame.')
                             "was not stored as such")
         if isinstance(cats, dict):
             return cats
-        return {k: v for k, v in categ.items() if k in cats}
+        out = {k: v for k, v in categ.items() if k in cats}
+        out.update({c: None for c in cats if c not in categ})
+        return out
 
     @property
     def has_pandas_metadata(self):

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -863,7 +863,7 @@ selection does not match number of rows in DataFrame.')
         if isinstance(cats, dict):
             return cats
         out = {k: v for k, v in categ.items() if k in cats}
-        out.update({c: None for c in cats if c not in categ})
+        out.update({c: pd.RangeIndex(0, 2**14) for c in cats if c not in categ})
         return out
 
     @property

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -489,6 +489,9 @@ def read_col(column, schema_helper, infile, use_cat=False,
                                        'number of category labels (%i)' %
                                        (assign.dtype, len(dic)))
             continue
+        elif use_cat and dic is None:
+            raise TypeError("Attempt to load as categorical a column with no dictionary")
+
         if ph.type == parquet_thrift.PageType.DATA_PAGE_V2:
             num += read_data_page_v2(infile, schema_helper, se, ph.data_page_header_v2, cmd,
                                      dic, assign, num, use_cat, off, ph, row_idx, selfmade=selfmade,
@@ -554,6 +557,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
                 piece = piece._data
             if use_cat and not d:
                 # only possible for multi-index
+                breakpoint()
                 val = convert(val, se)
                 try:
                     i = pd.Categorical(val)

--- a/fastparquet/core.py
+++ b/fastparquet/core.py
@@ -489,7 +489,7 @@ def read_col(column, schema_helper, infile, use_cat=False,
                                        'number of category labels (%i)' %
                                        (assign.dtype, len(dic)))
             continue
-        elif use_cat and dic is None:
+        elif use_cat and dic is None and getattr(catdef, "_multiindex", False) is False:
             raise TypeError("Attempt to load as categorical a column with no dictionary")
 
         if ph.type == parquet_thrift.PageType.DATA_PAGE_V2:
@@ -557,7 +557,6 @@ def read_col(column, schema_helper, infile, use_cat=False,
                 piece = piece._data
             if use_cat and not d:
                 # only possible for multi-index
-                breakpoint()
                 val = convert(val, se)
                 try:
                     i = pd.Categorical(val)

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -171,6 +171,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
 
             x = Dummy()
             x._set_categories = set_cats
+            x._multiindex = True
 
             d = np.zeros(size, dtype=int)
             if PANDAS_VERSION >= Version("0.24.0"):

--- a/fastparquet/test/test_api.py
+++ b/fastparquet/test/test_api.py
@@ -1503,3 +1503,13 @@ def test_var_dtypes():
 def test_not_a_path():
     with pytest.raises(FileNotFoundError):
         ParquetFile("notadir")
+
+
+def test_cat_not_cat(tempdir):
+    fn = os.path.join(tempdir, 'test.parquet')
+    df = pd.DataFrame({'val': [1]})
+    write(fn, df)
+
+    pf = ParquetFile(fn)
+    with pytest.raises(TypeError):
+        pf.to_pandas(categories=["val"])


### PR DESCRIPTION
Because we know that in this case, there cannot be a conflict between the cat encoding of one row group and the next. (technically, multiple dictionaries are allowed in a single row-group, but this never happens and would raise an exception anyway).

Fixes #862 