### PR TITLE
docstring for ParquetFile updated

### DIFF
--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -57,7 +57,8 @@ class ParquetFile(object):
     pandas_nulls: bool (True)
         If True, columns that are int or bool in parquet, but have nulls, will become
         pandas nullale types (Uint, Int, boolean). If False (the only behaviour
-        prior to v0.7.0), both kinds will be cast to float, and nulls will be NaN.
+        prior to v0.7.0), both kinds will be cast to float, and nulls will be NaN
+        unless pandas metadata indicates that the original datatype was nullable.
         Pandas nullable types were introduces in v1.0.0, but were still marked as
         experimental in v1.3.0.
 

--- a/fastparquet/api.py
+++ b/fastparquet/api.py
@@ -58,7 +58,7 @@ class ParquetFile(object):
         If True, columns that are int or bool in parquet, but have nulls, will become
         pandas nullale types (Uint, Int, boolean). If False (the only behaviour
         prior to v0.7.0), both kinds will be cast to float, and nulls will be NaN
-        unless pandas metadata indicates that the original datatype was nullable.
+        unless pandas metadata indicates that the original datatypes were nullable.
         Pandas nullable types were introduces in v1.0.0, but were still marked as
         experimental in v1.3.0.
 


### PR DESCRIPTION
pandas_nullable=False only takes effect when pandas metadata is absent in the original file.
