### PR TITLE
Use dt units in empty() (tz path)

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -195,7 +195,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
 
             values = Categorical.from_codes(codes=code, dtype=bvalues.dtype)
 
-        elif getattr(bvalues.dtype, 'tz', None):
+        elif isinstance(dtype, pd.DatetimeTZDtype):
             dt = "M8[ns]" if PANDAS_VERSION.major < 2 else f'M8[{bvalues.dtype.unit}]'
             values = np.zeros(shape=shape, dtype=dt)
             values = type(bvalues)._from_sequence(values, copy=False, dtype=bvalues.dtype)

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -196,8 +196,9 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
             values = Categorical.from_codes(codes=code, dtype=bvalues.dtype)
 
         elif getattr(bvalues.dtype, 'tz', None):
-            values = np.zeros(shape=shape, dtype='M8[ns]')
-            values = type(bvalues)(values, dtype=bvalues.dtype)
+            dt = "M8[ns]" if PANDAS_VERSION.major < 2 else f'M8[{bvalues.dtype.unit}]'
+            values = np.zeros(shape=shape, dtype=dt)
+            values = type(bvalues)._from_sequence(values, copy=False, dtype=bvalues.dtype)
         else:
             if not isinstance(bvalues, np.ndarray):
                 # e.g. DatetimeLikeBlock backed by DatetimeArray/TimedeltaArray

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -5,7 +5,8 @@ import numpy as np
 from pandas import (
     Categorical, DataFrame, Series,
     CategoricalIndex, RangeIndex, Index, MultiIndex,
-    DatetimeIndex, CategoricalDtype
+    DatetimeIndex, CategoricalDtype,
+    DatetimeTZDtype
 )
 from pandas.core.arrays.masked import BaseMaskedDtype
 import warnings
@@ -195,7 +196,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
 
             values = Categorical.from_codes(codes=code, dtype=bvalues.dtype)
 
-        elif isinstance(dtype, pd.DatetimeTZDtype):
+        elif isinstance(bvalues.dtype, DatetimeTZDtype):
             dt = "M8[ns]" if PANDAS_VERSION.major < 2 else f'M8[{bvalues.dtype.unit}]'
             values = np.zeros(shape=shape, dtype=dt)
             values = type(bvalues)._from_sequence(values, copy=False, dtype=bvalues.dtype)


### PR DESCRIPTION
Fixes #891 

@jbrockmendel - does this look right to you?
Should I be worried to be going back to using the underscored method?