### PR TITLE
fix dtype-str concatenation bug in empty()

### DIFF
--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -107,7 +107,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                 # funky pandas not-dtype
                 t = t.base
             if ("M" in str(t) or "time" in str(t)) and "[" not in str(t):
-                t = t + "[ns]"
+                t = str(t) + "[ns]"
             d = np.empty(0, dtype=t)
             if d.dtype.kind == "M" and str(col) in timezones:
                 try:


### PR DESCRIPTION
Bug discovered here: https://github.com/martindurant/uavro/pull/10

t is always a dtype.  You can't concatenate a dtype with a str.  So when this case is hit, it raises.  The line below, (`d = np.empty(0, dtype=t)`) works as desired when t is a str.