### PR TITLE
issue #904. Err when no props in metadata

### DIFF
--- a/fastparquet/util.py
+++ b/fastparquet/util.py
@@ -297,7 +297,7 @@ def update_custom_metadata(obj, custom_metadata : dict):
         Thrift object or parquet file which metadata is to update.
     custom_metadata : dict
         Key-value metadata to update in thrift object.
-        
+        The values must be strings or binary. To pass a dictionary, serialize it as json string then encode it in binary.
     Notes
     -----
     Key-value metadata are expected binary encoded. This function ensures it
@@ -305,6 +305,10 @@ def update_custom_metadata(obj, custom_metadata : dict):
     """
     kvm = (obj.key_value_metadata if isinstance(obj, ThriftObject)
            else obj.fmd.key_value_metadata)
+    
+    if kvm is None:
+        kvm=[]
+
     # Spare list of keys.
     kvm_keys = [item.key for item in kvm]
     for key, value in custom_metadata.items():

--- a/fastparquet/writer.py
+++ b/fastparquet/writer.py
@@ -1605,12 +1605,14 @@ def update_file_custom_metadata(path: str, custom_metadata: dict,
       - If its value is `None`, it is not added, and if found in existing,
         it is removed from existing.
 
+
     Parameters
     ----------
     path : str
         Local path to file.
     custom_metadata : dict
         Key-value metadata to update in thrift object.
+        The values must be strings or binary. To pass a dictionary, serialize it as json string then encode it in binary.
     is_metadata_file : bool, default None
         Define if target file is a pure metadata file, or is a parquet data
         file. If `None`, is set depending file name.


### PR DESCRIPTION
Workaround sporadic crashes when calling update_file_custom_metadata on files with an empty list of metadata properties. #904 