### PR TITLE
Use np.int64 type for day to nanosecond conversion (NEP50)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,36 +70,6 @@ jobs:
         run: |
           echo "FASTPARQUET_DATAPAGE_V2=$FASTPARQUET_DATAPAGE_V2"
           pytest --verbose --cov=fastparquet
-  dask:
-    name: dask
-    runs-on: ubuntu-latest
-    steps:
-      - name: APT
-        run: sudo apt-get install liblzo2-dev
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: ci/environment-py39.yml
-
-      - name: pip-install
-        shell: bash -l {0}
-        run: |
-          git clone https://github.com/dask/dask
-          pip install pyarrow
-          pip install -e dask/
-          pip install -e . --no-deps
-
-      - name: Run Tests
-        shell: bash -l {0}
-        run: |
-          pytest --verbose dask/dask/dataframe/io/tests/test_parquet.py
-  
   pandas:
     name: pandas
     runs-on: ubuntu-latest

--- a/fastparquet/dataframe.py
+++ b/fastparquet/dataframe.py
@@ -153,7 +153,7 @@ def empty(types, size, cats=None, cols=None, index_types=None, index_names=None,
                     tz_to_dt_tz(timezones[str(col)]))
             else:
                 index = Index(d)
-            views[col] = index.values
+            views[col] = d
     else:
         index = MultiIndex([[]], [[]])
         # index = MultiIndex.from_arrays(indexes)

--- a/fastparquet/test/test_output.py
+++ b/fastparquet/test/test_output.py
@@ -1022,9 +1022,7 @@ def test_no_string(tmpdir):
     df["A"] = df["A"].astype(pd.StringDtype())
 
     # set *all* values to NA
-    df["A"].iloc[0] = pd.NA
-    df["A"].iloc[1] = pd.NA
-    df["A"].iloc[2] = pd.NA
+    df.loc[:, "A"] = pd.NA
     df.to_parquet(fn, engine="fastparquet")
     df2 = pd.read_parquet(fn)
     assert pd.isna(df2.A).all()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython >= 0.29.23", "oldest-supported-numpy", "pytest-runner"]
+requires = ["setuptools", "setuptools_scm", "Cython >= 0.29.23", "numpy>=2.0.0rc1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=1.5.0
-numpy>=1.20.3
+numpy
 cramjam>=2.3
 fsspec
 packaging

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,6 @@ setup(
         'local_scheme': 'no-local-version',
         'write_to': 'fastparquet/_version.py'
     },
-    setup_requires=[
-        'setuptools>18.0',
-        'setuptools-scm>1.5.4',
-        'Cython',
-        'pytest-runner',
-        'oldest-supported-numpy'
-    ],
     description='Python support for Parquet file format',
     author='Martin Durant',
     author_email='mdurant@anaconda.com',


### PR DESCRIPTION
Fixes #921.
Fixes #923 (after release)

Required due to a change in numpy's type promotion with numpy >= 2:
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion
[NEP 50 -- Promotion rules for Python scalars](https://numpy.org/neps/nep-0050-scalar-promotion.html)

The `DAYS_TO_MILLIS` constant actually contained the number of *nanoseconds* in a day, so I renamed it. I hope this is not incorrectly used outside of fastparquet. At least it is not part of the API documentation.