### PR TITLE
CI: enable string dtype for test job with pandas main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
+        env:
+          PANDAS_FUTURE_INFER_STRING: 1
         run: |
           pytest -v  fastparquet/ # fastparquet test suite against dev pandas
           pytest --verbose pandas/pandas/tests/io/test_parquet.py


### PR DESCRIPTION
Currently you still have to enable this manually even when using pandas main (although it is probably time now to switch the default on the pandas side). When enabling this, this should also show that the simple test that was added in https://github.com/dask/fastparquet/pull/933 is failing again (related to a `np.array(inp, copy=False)` call that now errors if `copy=False` cannot be honored, this was a change in numpy 2+, that pandas will start following in 3.0)