### PR TITLE
Complete versioneer replacement with setuptools_scm for version management

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -53,6 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -81,6 +91,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
@@ -116,6 +131,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,6 +109,7 @@ jobs:
           pip install hypothesis
           pip install pytest-localserver pytest-xdist pytest-asyncio
           pip install -e . --no-deps # Install fastparquet
+          pip install versioneer # Needed for pandas build
           git clone https://github.com/pandas-dev/pandas
           cd pandas
           python setup.py build_ext -j 4

--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -18,6 +18,5 @@ dependencies:
   - orjson
   - ujson
   - python-rapidjson
-  - versioneer
   - meson-python
   - pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
 requires = ["setuptools", "setuptools_scm", "Cython >= 0.29.23", "numpy>=2.0.0rc1"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "fastparquet/_version.py"
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,3 @@ test=pytest
 
 [tool:pytest]
 addopts = -vv
-
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = fastparquet/_version.py
-versionfile_build = fastparquet/_version.py
-tag_prefix = ""

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,7 @@ subprocess.call(["git", "status"], stdout=sys.stdout, stderr=sys.stderr)
 
 setup(
     name='fastparquet',
-    use_scm_version={
-        'version_scheme': 'guess-next-dev',
-        'local_scheme': 'no-local-version',
-        'write_to': 'fastparquet/_version.py'
-    },
+    use_scm_version=True,
     description='Python support for Parquet file format',
     author='Martin Durant',
     author_email='mdurant@anaconda.com',


### PR DESCRIPTION
# Fix version handling with setuptools_scm

PR to solves [issue 950](https://github.com/dask/fastparquet/issues/950), where fastparquet version number is not correctly generated when CI is runned from a fork.

This PR finalilzes versioneer replacement with setuptools_scm for version management. The changes are focused on making the version system work properly.

## Disclaimer

I have no experience in version system management, only in analyzing failing runs.
I conducted the analysis with help of Cursor AI + Claude 3.7 Sonnet, and the AI agent made the changes.
I double-checked them to prevent any change that would seem to me out of place.
Only these remaining changes appear to me the ones required to solve the problem.

## Changes

1. **Remove versioneer**:
   - Removed versioneer configuration from setup.cfg
   - Removed versioneer dependency from CI environment file

2. **Configure setuptools_scm properly**:
   - Moved setuptools_scm configuration from setup.py to pyproject.toml
   - Simplified setup.py to use `use_scm_version=True` to defer to pyproject.toml config

3. **Improve tag handling in CI**:
   - Added upstream tag fetching in GitHub Actions workflows so CI builds have access to all tags

These changes ensure that version information is correctly generated during builds, especially in CI environments where git tags might not be fully available.

## Testing

The changes have been tested in CI which now runs successfully.