### PR TITLE
Finalize use of setuptools_scm for version management

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -53,6 +58,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -82,6 +92,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -94,6 +109,7 @@ jobs:
           pip install hypothesis
           pip install pytest-localserver pytest-xdist pytest-asyncio
           pip install -e . --no-deps # Install fastparquet
+          pip install versioneer # Needed for pandas build
           git clone https://github.com/pandas-dev/pandas
           cd pandas
           python setup.py build_ext -j 4
@@ -116,6 +132,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch upstream tags
+        run: |
+          git remote add upstream https://github.com/dask/fastparquet.git
+          git fetch upstream --tags
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -18,6 +18,5 @@ dependencies:
   - orjson
   - ujson
   - python-rapidjson
-  - versioneer
   - meson-python
   - pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
 requires = ["setuptools", "setuptools_scm", "Cython >= 0.29.23", "numpy>=2.0.0rc1"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "fastparquet/_version.py"
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,14 +3,3 @@ test=pytest
 
 [tool:pytest]
 addopts = -vv
-
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = fastparquet/_version.py
-versionfile_build = fastparquet/_version.py
-tag_prefix = ""

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,7 @@ subprocess.call(["git", "status"], stdout=sys.stdout, stderr=sys.stderr)
 
 setup(
     name='fastparquet',
-    use_scm_version={
-        'version_scheme': 'guess-next-dev',
-        'local_scheme': 'no-local-version',
-        'write_to': 'fastparquet/_version.py'
-    },
+    use_scm_version=True,
     description='Python support for Parquet file format',
     author='Martin Durant',
     author_email='mdurant@anaconda.com',


### PR DESCRIPTION
Fetch and copy tags from upstream to remote so that when a PR is pushed from a remote, the CI runs correctly.

This PR replaces PR #951 
I had a mess with the commits from the initial PR, and I have re-created this one instead.

To keep track of the discussions we have had in PR 951:
pandas CI is still failing, and the error message has been submitted to pandas github to get some help understanding what is wrong ([ticket 61156](https://github.com/pandas-dev/pandas/issues/61156)).
